### PR TITLE
docs/fix: replace magic numbers with constants and add inline code comments

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,3 +1,3 @@
 {
-  "ignores": ["CHANGELOG.md", ".metadata"],
+  "ignores": ["CHANGELOG.md", ".metadata"]
 }

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,3 +1,3 @@
 {
-  "ignores": ["CHANGELOG.md"],
+  "ignores": ["CHANGELOG.md", ".metadata"],
 }

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -98,8 +98,9 @@ class UvApiException implements Exception {
   /// The response body, or a synthesized error message on parse failure.
   final String body;
 
-  // Override toString so exception messages include the status code and body
-  // instead of the default unhelpful "Instance of 'UvApiException'".
+  // Override toString for debuggability only - the app works without it.
+  // Without this, logs and error messages show "Instance of 'UvApiException'"
+  // which is useless. This makes it readable: "UvApiException(404): Not Found".
   @override
   String toString() => 'UvApiException($statusCode): $body';
 }

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -5,6 +5,7 @@ import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 
 const _defaultTimeout = Duration(seconds: 10);
+const _httpOk = 200;
 
 /// HTTP client for fetching UV data from the proxy API.
 class UvApi {
@@ -62,7 +63,7 @@ class UvApi {
         .get(uri, headers: {'X-Device-ID': uuid})
         .timeout(_timeout);
 
-    if (response.statusCode != 200) {
+    if (response.statusCode != _httpOk) {
       throw UvApiException(response.statusCode, response.body);
     }
 

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -98,6 +98,8 @@ class UvApiException implements Exception {
   /// The response body, or a synthesized error message on parse failure.
   final String body;
 
+  // Override toString so exception messages include the status code and body
+  // instead of the default unhelpful "Instance of 'UvApiException'".
   @override
   String toString() => 'UvApiException($statusCode): $body';
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,8 +5,10 @@ class UvAlertApp extends StatelessWidget {
   /// Creates the [UvAlertApp].
   const UvAlertApp({super.key});
 
-  // Override build to define the widget tree. Required by StatelessWidget;
-  // Flutter calls this whenever the widget needs to be rendered.
+  // Override build to define the widget tree. This is not optional -
+  // StatelessWidget declares build as abstract with no default body,
+  // so Dart will not compile without it. Flutter calls this whenever
+  // the widget needs to be rendered.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,6 +5,8 @@ class UvAlertApp extends StatelessWidget {
   /// Creates the [UvAlertApp].
   const UvAlertApp({super.key});
 
+  // Override build to define the widget tree. Required by StatelessWidget;
+  // Flutter calls this whenever the widget needs to be rendered.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/foundation.dart';
 
-DateTime _fromEpochSeconds(int s) =>
-    DateTime.fromMillisecondsSinceEpoch(s * 1000, isUtc: true);
+const _msPerSecond = 1000;
 
-int _toEpochSeconds(DateTime dt) => dt.millisecondsSinceEpoch ~/ 1000;
+DateTime _fromEpochSeconds(int s) =>
+    DateTime.fromMillisecondsSinceEpoch(s * _msPerSecond, isUtc: true);
+
+int _toEpochSeconds(DateTime dt) => dt.millisecondsSinceEpoch ~/ _msPerSecond;
 
 /// A single UV index reading at a point in time.
 @immutable

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -136,10 +136,9 @@ class UvData {
 
   // Override == for value equality: two UvData instances with identical fields
   // are equal regardless of whether they are the same object in memory.
-  // Needed so Riverpod/Flutter can detect when fetched data has not changed
-  // and skip unnecessary rebuilds.
-  // `other` is the Dart SDK's parameter name from Object.==; it is the
-  // right-hand operand being compared against `this`.
+  // Enables value-based comparisons in tests and correct behavior with
+  // listEquals. `other` is the Dart SDK's parameter name from Object.==; it is
+  // the right-hand operand being compared against `this`.
   @override
   bool operator ==(Object other) =>
       other is UvData &&

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -28,10 +28,17 @@ class UvForecastEntry {
   /// Serializes this entry to a JSON map.
   Map<String, dynamic> toJson() => {'dt': _toEpochSeconds(time), 'uvi': uvi};
 
+  // Override == for value equality: two entries with identical time and uvi
+  // are equal regardless of whether they are the same object in memory.
+  // Required so listEquals() in UvData.== can compare entries by value.
+  // `other` is the Dart SDK's parameter name from Object.==; it is the
+  // right-hand operand being compared against `this`.
   @override
   bool operator ==(Object other) =>
       other is UvForecastEntry && other.time == time && other.uvi == uvi;
 
+  // Override hashCode whenever == is overridden. Dart requires that objects
+  // which are == produce the same hashCode, otherwise Sets and Maps break.
   @override
   int get hashCode => Object.hash(time, uvi);
 }
@@ -125,6 +132,12 @@ class UvData {
     };
   }
 
+  // Override == for value equality: two UvData instances with identical fields
+  // are equal regardless of whether they are the same object in memory.
+  // Needed so Riverpod/Flutter can detect when fetched data has not changed
+  // and skip unnecessary rebuilds.
+  // `other` is the Dart SDK's parameter name from Object.==; it is the
+  // right-hand operand being compared against `this`.
   @override
   bool operator ==(Object other) =>
       other is UvData &&
@@ -138,6 +151,8 @@ class UvData {
       listEquals(other.hourly, hourly) &&
       listEquals(other.daily, daily);
 
+  // Override hashCode whenever == is overridden. Dart requires that objects
+  // which are == produce the same hashCode, otherwise Sets and Maps break.
   @override
   int get hashCode => Object.hashAll([
     currentUvi,

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -4,6 +4,8 @@ import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
 
+const _msPerSecond = 1000;
+
 DateTime _staleTimestamp() =>
     DateTime.now().toUtc().subtract(const Duration(hours: 25));
 
@@ -11,7 +13,7 @@ UvData _makeData({DateTime? fetchedAt}) {
   final raw = fetchedAt ?? DateTime.now().toUtc();
   // Truncate to whole seconds: epoch-seconds serialization has 1s precision.
   final now = DateTime.fromMillisecondsSinceEpoch(
-    raw.millisecondsSinceEpoch - raw.millisecondsSinceEpoch % 1000,
+    raw.millisecondsSinceEpoch - raw.millisecondsSinceEpoch % _msPerSecond,
     isUtc: true,
   );
   return UvData(

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -4,10 +4,13 @@ import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
 
-const _msPerSecond = 1000;
+const int _msPerSecond = 1000;
+const int _cacheMaxAgeHours = 24;
+const int _staleHours = _cacheMaxAgeHours + 1;
+const int _freshHours = _cacheMaxAgeHours - 1;
 
 DateTime _staleTimestamp() =>
-    DateTime.now().toUtc().subtract(const Duration(hours: 25));
+    DateTime.now().toUtc().subtract(const Duration(hours: _staleHours));
 
 UvData _makeData({DateTime? fetchedAt}) {
   final raw = fetchedAt ?? DateTime.now().toUtc();
@@ -66,7 +69,9 @@ void main() {
     });
 
     test('is not stale when timestamp is 23 hours old', () async {
-      final recent = DateTime.now().toUtc().subtract(const Duration(hours: 23));
+      final recent = DateTime.now().toUtc().subtract(
+        const Duration(hours: _freshHours),
+      );
       await cache.store(_makeData(fetchedAt: recent));
       expect(cache.isStale, isFalse);
     });

--- a/test/uv_model_test.dart
+++ b/test/uv_model_test.dart
@@ -1,6 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:uvalert/models/uv_model.dart';
 
+const int _secondsPerHour = 3600;
+const int _utcMinus5OffsetSeconds = -5 * _secondsPerHour;
+
 void main() {
   final sampleJson = <String, dynamic>{
     'current': {
@@ -17,7 +20,7 @@ void main() {
       {'dt': 1700000000, 'uvi': 9.1},
     ],
     'timezone': 'America/New_York',
-    'timezone_offset': -18000,
+    'timezone_offset': _utcMinus5OffsetSeconds,
     'fetched_at': 1699963200,
   };
 
@@ -74,7 +77,7 @@ void main() {
       expect(data.currentUvi, 7.5);
       expect(data.clouds, 20);
       expect(data.timezone, 'America/New_York');
-      expect(data.timezoneOffset, -18000);
+      expect(data.timezoneOffset, _utcMinus5OffsetSeconds);
       expect(data.hourly.length, 2);
       expect(data.daily.length, 1);
       expect(data.hourly[1].uvi, 8.2);


### PR DESCRIPTION
## Summary
- Replace magic numbers with named constants across HTTP status checks, milliseconds conversion, cache expiration logic, and timezone offset in `sampleJson`
- Add inline comments explaining non-obvious operator overrides (`==`, `hashCode`, `toString`) in `UvData`, `UvForecastEntry`, and `UvApiException`
- Minor chore: format `.markdownlint-cli2.jsonc` and update markdownlint ignores

## Test plan
- [ ] All existing tests pass
- [ ] No new linter warnings introduced