### PR TITLE
docs: add docs, prettier config, and constant cleanup

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "none"
+}

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,182 @@
+# UV Alert - Developer Onboarding
+
+## What Is This?
+
+UV Alert is a Flutter app that monitors the UV index at your location and sends
+notifications when exposure risk is high. It targets Android (API 21+) and
+Linux desktop.
+
+The app fetches UV data from a Vercel proxy API using GPS coordinates or a
+manually entered location, caches responses for 24 hours, and surfaces hourly
+and daily UV forecasts.
+
+**Current state (v1.1.0):** Core infrastructure is complete - models, API
+client, cache, preferences, Riverpod scaffold, and a full unit test suite. The
+UI screens (`dashboard_screen`, `settings_screen`, `onboarding_screen`) and
+background service implementations are stubs. The app renders a `Placeholder`
+as its home widget.
+
+## Prerequisites
+
+| Tool    | Version        |
+| ------- | -------------- |
+| Flutter | stable channel |
+| Dart    | ^3.11.4        |
+| Android | API 21+        |
+
+Install Flutter from [flutter.dev](https://flutter.dev/docs/get-started/install)
+and confirm you are on the stable channel:
+
+```sh
+flutter channel stable
+flutter upgrade
+flutter doctor
+```
+
+## Getting the Code
+
+```sh
+git clone https://github.com/milliorn/uv-alert.git
+cd uv-alert
+flutter pub get
+```
+
+There is a companion repo, `uv-alert-proxy`, which is the Vercel proxy the app
+calls. You do not need it to run the Flutter app locally, but you will need it
+if you are working on the API layer.
+
+## Running the App
+
+```sh
+# On a connected Android device or emulator
+flutter run
+
+# On Linux desktop
+flutter run -d linux
+```
+
+## Running Tests
+
+```sh
+# All tests with coverage
+flutter test --coverage
+
+# A single test file
+flutter test test/cache_test.dart
+```
+
+CI enforces **100% line coverage** on every pull request. New code must ship
+with tests that maintain full coverage - no exceptions.
+
+## Linting and Analysis
+
+```sh
+flutter analyze
+```
+
+This project uses
+[very_good_analysis](https://pub.dev/packages/very_good_analysis) (`^10.2.0`).
+Strict inference, strict casts, and strict raw types are all enabled. All
+analysis warnings are treated as errors - CI fails on any lint violation,
+including infos (`--fatal-infos`).
+
+Documentation links are also validated:
+
+```sh
+dart doc --validate-links
+```
+
+## Codebase Layout
+
+```text
+lib/
+  api/
+    uv_api.dart          # HTTP client; cache-first fetch; throws UvApiException
+  models/
+    uv_model.dart        # UvData and UvForecastEntry; JSON serialization
+  storage/
+    cache.dart           # 24-hour SharedPreferences cache; isValid = !isEmpty && !isStale
+    preferences.dart     # Typed wrapper for all SharedPreferences keys (prefix: uvalert_)
+  constants.dart         # Shared compile-time constants (msPerSecond, etc.)
+  app.dart               # Root MaterialApp widget; Material 3 theme
+  main.dart              # Entry point; ProviderScope; zone error hooks
+
+test/
+  cache_test.dart
+  preferences_test.dart
+  uv_api_test.dart
+  uv_model_test.dart
+  widget_test.dart
+```
+
+## How the Data Flows
+
+1. A caller invokes `UvApi.fetch(lat, lon, uuid)`.
+2. `UvApi` checks the cache first (`Cache.isValid`). If valid, returns the
+   cached `UvData` without a network call.
+3. If stale or empty, it hits the proxy: `GET /api/uv?lat=…&lon=…` with an
+   `X-Device-ID` header containing the device UUID.
+4. The response is parsed into `UvData`, stored in `Cache` (keyed on the
+   server-provided `fetchedAt` timestamp), and returned.
+
+State management is [Riverpod](https://riverpod.dev). The app is wrapped in
+`ProviderScope` in `main.dart`. Widgets that need data extend `ConsumerWidget`
+and read from providers in `lib/providers/` (stubs right now).
+
+## Key Behaviors to Know
+
+- **Cache TTL:** 24 hours, keyed to the server's `fetchedAt` timestamp, not
+  `DateTime.now()`. If the server timestamp lags real time, the cache expires
+  sooner - this is intentional.
+- **Cache staleness:** `isStale` has no `.abs()` call. Data fetched in the
+  future (clock skew) appears fresh, not stale.
+- **HTTP client ownership:** `UvApi` owns its `http.Client` by default and
+  closes it on `dispose()`. Pass your own client to share or mock it - it will
+  not be closed by `dispose()`.
+- **Error handling:** `UvApiException` is thrown on any non-200 response or
+  parse failure. Two separate error hooks live in `main.dart` - `FlutterError.onError`
+  for framework errors and `runZonedGuarded` for async errors. They must stay
+  separate; both have a TODO to wire up crash reporting.
+- **Preferences keys:** All `SharedPreferences` keys are prefixed `uvalert_`.
+  See `lib/storage/preferences.dart` for the full list.
+
+## Making Changes
+
+Branch off `main`, commit with
+[Conventional Commits](https://www.conventionalcommits.org/), and open a PR
+against `main`.
+
+```sh
+git checkout -b feat/your-feature
+# ... make changes ...
+git commit -m "feat: describe what you added"
+```
+
+Common prefixes: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`.
+
+CI runs automatically on every PR:
+
+1. `flutter analyze --fatal-infos` - must pass with zero issues
+2. `dart doc --validate-links` - docs must be valid
+3. `flutter test --coverage` - all tests must pass
+4. 100% line coverage gate - no regressions
+
+Dependabot keeps pub, Gradle, and GitHub Actions dependencies up to date
+monthly. Patch and minor Dependabot PRs are auto-merged once CI passes.
+Releases are managed by Release Please and cut automatically on pushes to
+`main`.
+
+## Open Work
+
+The following are known stubs waiting to be implemented:
+
+- `lib/screens/` - `dashboard_screen`, `settings_screen`, `onboarding_screen`
+- `lib/providers/` - Riverpod providers wiring API and preferences to UI
+- `lib/services/` - `workmanager` background refresh and
+  `flutter_local_notifications` alert dispatch
+- Crash reporting - TODO comments in `main.dart` mark where Sentry or
+  Firebase Crashlytics should be wired in
+- Manual location - stored as a raw string; needs migration to a structured
+  lat/lon type when the location feature lands
+- Retry logic - `UvApi.fetch` has a TODO for exponential backoff on
+  `TimeoutException`

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -15,9 +15,9 @@ and daily UV forecasts.
 
 **Current state (v1.0.0+1):** Core infrastructure is complete - models, API
 client, cache, preferences, Riverpod scaffold, and a full unit test suite. The
-UI screens (`dashboard_screen`, `settings_screen`, `onboarding_screen`) and
-background service implementations are stubs. The app renders a `Placeholder`
-as its home widget.
+UI screens (`dashboard_screen`, `settings_screen`, `onboarding_screen`),
+Riverpod providers, and background service implementations are not yet
+implemented. The app renders a `Placeholder` as its home widget.
 
 ## Prerequisites
 
@@ -121,7 +121,7 @@ test/
 
 State management is [Riverpod](https://riverpod.dev). The app is wrapped in
 `ProviderScope` in `main.dart`. Widgets that need data extend `ConsumerWidget`
-and read from providers in `lib/providers/` (stubs right now).
+and read from providers in `lib/providers/` (not yet implemented).
 
 ## Key Behaviors to Know
 
@@ -168,7 +168,7 @@ Releases are managed by Release Please and cut automatically on pushes to
 
 ## Open Work
 
-The following are known stubs waiting to be implemented:
+The following are not yet implemented (no files or directories exist yet):
 
 - `lib/screens/` - `dashboard_screen`, `settings_screen`, `onboarding_screen`
 - `lib/providers/` - Riverpod providers wiring API and preferences to UI

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -9,9 +9,9 @@ The app fetches UV data from a Vercel proxy API using GPS coordinates or a
 manually entered location, caches responses for 24 hours, and surfaces hourly
 and daily UV forecasts.
 
-> **Planned platforms:** Linux desktop, iOS, and other Flutter targets are
-> planned for future releases. The platform scaffolds (`linux/`, `ios/`, etc.)
-> have not been generated yet.
+> **Planned platforms:** Linux desktop and other Flutter targets are planned
+> for future releases. The platform scaffolds (`linux/`, etc.) have not been
+> generated yet.
 
 **Current state (v1.0.0+1):** Core infrastructure is complete - models, API
 client, cache, preferences, Riverpod scaffold, and a full unit test suite. The

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -168,12 +168,15 @@ Releases are managed by Release Please and cut automatically on pushes to
 
 ## Open Work
 
-The following are not yet implemented (no files or directories exist yet):
+The following directories and features do not exist yet:
 
 - `lib/screens/` - `dashboard_screen`, `settings_screen`, `onboarding_screen`
 - `lib/providers/` - Riverpod providers wiring API and preferences to UI
 - `lib/services/` - `workmanager` background refresh and
   `flutter_local_notifications` alert dispatch
+
+The following are partially implemented with TODOs in existing files:
+
 - Crash reporting - TODO comments in `main.dart` mark where Sentry or
   Firebase Crashlytics should be wired in
 - Manual location - stored as a raw string; needs migration to a structured

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -111,7 +111,7 @@ test/
 
 ## How the Data Flows
 
-1. A caller invokes `UvApi.fetch(lat, lon, uuid)`.
+1. A caller invokes `UvApi.fetch(lat: lat, lon: lon, uuid: uuid)`.
 2. `UvApi` checks the cache first (`Cache.isValid`). If valid, returns the
    cached `UvData` without a network call.
 3. If stale or empty, it hits the proxy: `GET /api/uv?lat=…&lon=…` with an

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -10,7 +10,7 @@ The app fetches UV data from a Vercel proxy API using GPS coordinates or a
 manually entered location, caches responses for 24 hours, and surfaces hourly
 and daily UV forecasts.
 
-**Current state (v1.1.0):** Core infrastructure is complete - models, API
+**Current state (v1.0.0+1):** Core infrastructure is complete - models, API
 client, cache, preferences, Riverpod scaffold, and a full unit test suite. The
 UI screens (`dashboard_screen`, `settings_screen`, `onboarding_screen`) and
 background service implementations are stubs. The app renders a `Placeholder`

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -3,12 +3,15 @@
 ## What Is This?
 
 UV Alert is a Flutter app that monitors the UV index at your location and sends
-notifications when exposure risk is high. It targets Android (API 21+) and
-Linux desktop.
+notifications when exposure risk is high. It currently targets Android (API 21+).
 
 The app fetches UV data from a Vercel proxy API using GPS coordinates or a
 manually entered location, caches responses for 24 hours, and surfaces hourly
 and daily UV forecasts.
+
+> **Planned platforms:** Linux desktop, iOS, and other Flutter targets are
+> planned for future releases. The platform scaffolds (`linux/`, `ios/`, etc.)
+> have not been generated yet.
 
 **Current state (v1.0.0+1):** Core infrastructure is complete - models, API
 client, cache, preferences, Riverpod scaffold, and a full unit test suite. The
@@ -50,9 +53,6 @@ if you are working on the API layer.
 ```sh
 # On a connected Android device or emulator
 flutter run
-
-# On Linux desktop
-flutter run -d linux
 ```
 
 ## Running Tests

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -5,10 +5,6 @@ class UvAlertApp extends StatelessWidget {
   /// Creates the [UvAlertApp].
   const UvAlertApp({super.key});
 
-  // Override build to define the widget tree. This is not optional -
-  // StatelessWidget declares build as abstract with no default body,
-  // so Dart will not compile without it. Flutter calls this whenever
-  // the widget needs to be rendered.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,0 +1,2 @@
+/// Milliseconds in one second.
+const int msPerSecond = 1000;

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -1,11 +1,10 @@
 import 'package:flutter/foundation.dart';
-
-const _msPerSecond = 1000;
+import 'package:uvalert/constants.dart';
 
 DateTime _fromEpochSeconds(int s) =>
-    DateTime.fromMillisecondsSinceEpoch(s * _msPerSecond, isUtc: true);
+    DateTime.fromMillisecondsSinceEpoch(s * msPerSecond, isUtc: true);
 
-int _toEpochSeconds(DateTime dt) => dt.millisecondsSinceEpoch ~/ _msPerSecond;
+int _toEpochSeconds(DateTime dt) => dt.millisecondsSinceEpoch ~/ msPerSecond;
 
 /// A single UV index reading at a point in time.
 @immutable

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -4,7 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/preferences.dart';
 
-const _cacheMaxAgeHours = 24;
+/// Maximum age of cached UV data in hours before it is considered stale.
+const cacheMaxAgeHours = 24;
 
 /// SharedPreferences-backed cache for [UvData] with a 24-hour TTL.
 class Cache {
@@ -52,7 +53,7 @@ class Cache {
     }
   }
 
-  /// Whether the cached data has exceeded the 24-hour TTL.
+  /// Whether the cached data has exceeded the [cacheMaxAgeHours]-hour TTL.
   ///
   /// Returns `true` when no timestamp is stored or the timestamp is corrupt.
   bool get isStale {
@@ -70,7 +71,7 @@ class Cache {
 
     // No abs(): future fetched (clock skew) must appear fresh, not stale.
     return DateTime.now().toUtc().difference(fetched) >=
-        const Duration(hours: _cacheMaxAgeHours);
+        const Duration(hours: cacheMaxAgeHours);
   }
 
   /// Whether no payload is currently stored.

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -5,7 +5,7 @@ import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 /// Maximum age of cached UV data in hours before it is considered stale.
-const cacheMaxAgeHours = 24;
+const int cacheMaxAgeHours = 24;
 
 /// SharedPreferences-backed cache for [UvData] with a
 /// [cacheMaxAgeHours]-hour TTL.

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -23,7 +23,7 @@ class Cache {
       _prefs.setCachedPayload(json),
       // Intentional: use server-provided fetchedAt, not DateTime.now().
       // If the server timestamp lags real time, the cache expires sooner than
-      // _cacheMaxAgeHours — acceptable given UV data changes infrequently.
+      // cacheMaxAgeHours - acceptable given UV data changes infrequently.
       _prefs.setCachedPayloadAt(data.fetchedAt.toIso8601String()),
     ]);
   }

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -7,7 +7,8 @@ import 'package:uvalert/storage/preferences.dart';
 /// Maximum age of cached UV data in hours before it is considered stale.
 const cacheMaxAgeHours = 24;
 
-/// SharedPreferences-backed cache for [UvData] with a 24-hour TTL.
+/// SharedPreferences-backed cache for [UvData] with a
+/// [cacheMaxAgeHours]-hour TTL.
 class Cache {
   /// Creates a [Cache] backed by the given [Preferences] instance.
   Cache(this._prefs);

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -4,9 +4,8 @@ import 'package:uvalert/constants.dart';
 import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
-const int _cacheMaxAgeHours = 24;
-const int _staleHours = _cacheMaxAgeHours + 1;
-const int _freshHours = _cacheMaxAgeHours - 1;
+const int _staleHours = cacheMaxAgeHours + 1;
+const int _freshHours = cacheMaxAgeHours - 1;
 
 DateTime _staleTimestamp() =>
     DateTime.now().toUtc().subtract(const Duration(hours: _staleHours));

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -62,12 +62,12 @@ void main() {
       expect(cache.isStale, isFalse);
     });
 
-    test('is stale when timestamp is 25 hours old', () async {
+    test('is stale when timestamp is TTL + 1 hours old', () async {
       await cache.store(_makeData(fetchedAt: _staleTimestamp()));
       expect(cache.isStale, isTrue);
     });
 
-    test('is not stale when timestamp is 23 hours old', () async {
+    test('is not stale when timestamp is TTL - 1 hours old', () async {
       final recent = DateTime.now().toUtc().subtract(
         const Duration(hours: _freshHours),
       );

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -4,6 +4,7 @@ import 'package:uvalert/constants.dart';
 import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
+
 const int _staleHours = cacheMaxAgeHours + 1;
 const int _freshHours = cacheMaxAgeHours - 1;
 

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -1,10 +1,9 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/constants.dart';
 import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
-
-const int _msPerSecond = 1000;
 const int _cacheMaxAgeHours = 24;
 const int _staleHours = _cacheMaxAgeHours + 1;
 const int _freshHours = _cacheMaxAgeHours - 1;
@@ -16,7 +15,7 @@ UvData _makeData({DateTime? fetchedAt}) {
   final raw = fetchedAt ?? DateTime.now().toUtc();
   // Truncate to whole seconds: epoch-seconds serialization has 1s precision.
   final now = DateTime.fromMillisecondsSinceEpoch(
-    raw.millisecondsSinceEpoch - raw.millisecondsSinceEpoch % _msPerSecond,
+    raw.millisecondsSinceEpoch - raw.millisecondsSinceEpoch % msPerSecond,
     isUtc: true,
   );
   return UvData(


### PR DESCRIPTION
## Docs

- Added onboarding documentation for the UV Alert app covering architecture, setup, and current state
- Iteratively updated onboarding: current version, target platforms, and implementation status of UI screens and providers
- Updated cache TTL comment to reference `cacheMaxAgeHours` constant
- Removed unnecessary comments from `UvAlertApp` class

## Constants

- Added `msPerSecond` constant and updated usages throughout
- Replaced hardcoded `cacheMaxAgeHours` value with named constant

## Prettier

- Added `.prettierrc` configuration file
- Added `.prettierignore` to exclude `CHANGELOG.md`

## Style

- Added missing newline in cache file for code clarity