### PR TITLE
feat: add LocationNotifier with platform abstraction and improve type safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -45,7 +45,6 @@ analyzer:
     unawaited_futures: error
     parameter_assignments: error
     only_throw_errors: error
-    avoid_types_on_closure_parameters: ignore
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,7 +48,7 @@ analyzer:
 
 linter:
   rules:
-    omit_local_variable_types: false
+    always_specify_types: true
     public_member_api_docs: true
     require_trailing_commas: false
     avoid_futureor_void: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -48,6 +48,7 @@ analyzer:
 
 linter:
   rules:
+    omit_local_variable_types: false
     public_member_api_docs: true
     require_trailing_commas: false
     avoid_futureor_void: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -49,7 +49,8 @@ analyzer:
 
 linter:
   rules:
-    always_specify_types: true
+    avoid_dynamic_calls: true
+    always_specify_types: true # Forces explicit types instead of implicit dynamic
     omit_local_variable_types: false
     avoid_types_on_closure_parameters: false
     public_member_api_docs: true

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -45,6 +45,7 @@ analyzer:
     unawaited_futures: error
     parameter_assignments: error
     only_throw_errors: error
+    avoid_types_on_closure_parameters: ignore
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -49,6 +49,8 @@ analyzer:
 linter:
   rules:
     always_specify_types: true
+    omit_local_variable_types: false
+    avoid_types_on_closure_parameters: false
     public_member_api_docs: true
     require_trailing_commas: false
     avoid_futureor_void: true

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -4,8 +4,8 @@ import 'package:http/http.dart' as http;
 import 'package:uvalert/models/uv_model.dart';
 import 'package:uvalert/storage/cache.dart';
 
-const _defaultTimeout = Duration(seconds: 10);
-const _httpOk = 200;
+const Duration _defaultTimeout = Duration(seconds: 10);
+const int _httpOk = 200;
 
 /// HTTP client for fetching UV data from the proxy API.
 class UvApi {
@@ -48,19 +48,19 @@ class UvApi {
     required String uuid,
   }) async {
     if (_cache.isValid) {
-      final cached = await _cache.read();
+      final UvData? cached = await _cache.read();
 
       if (cached != null) return cached;
     }
 
-    final uri = Uri.parse(
+    final Uri uri = Uri.parse(
       '$_proxyBaseUrl/api/uv',
-    ).replace(queryParameters: {'lat': lat.toString(), 'lon': lon.toString()});
+    ).replace(queryParameters: <String, dynamic>{'lat': lat.toString(), 'lon': lon.toString()});
 
     // TODO(retry): add exponential backoff for TimeoutException
     //   and transient errors
-    final response = await _httpClient
-        .get(uri, headers: {'X-Device-ID': uuid})
+    final http.Response response = await _httpClient
+        .get(uri, headers: <String, String>{'X-Device-ID': uuid})
         .timeout(_timeout);
 
     if (response.statusCode != _httpOk) {

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -53,12 +53,12 @@ class UvApi {
       if (cached != null) return cached;
     }
 
-    final Uri uri = Uri.parse(
-      '$_proxyBaseUrl/api/uv',
-    ).replace(queryParameters: <String, dynamic>{
-      'lat': lat.toString(),
-      'lon': lon.toString(),
-    });
+    final Uri uri = Uri.parse('$_proxyBaseUrl/api/uv').replace(
+      queryParameters: <String, dynamic>{
+        'lat': lat.toString(),
+        'lon': lon.toString(),
+      },
+    );
 
     // TODO(retry): add exponential backoff for TimeoutException
     //   and transient errors

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -75,7 +75,7 @@ class UvApi {
     try {
       final Object? decoded = jsonDecode(response.body);
 
-      if (decoded is! Map<String, dynamic>) {
+      if (decoded is! Map<String, Object?>) {
         throw UvApiException(response.statusCode, response.body);
       }
 

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -54,7 +54,7 @@ class UvApi {
     }
 
     final Uri uri = Uri.parse('$_proxyBaseUrl/api/uv').replace(
-      queryParameters: <String, dynamic>{
+      queryParameters: <String, String>{
         'lat': lat.toString(),
         'lon': lon.toString(),
       },

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -73,7 +73,7 @@ class UvApi {
     final UvData data;
 
     try {
-      final dynamic decoded = jsonDecode(response.body);
+      final Object? decoded = jsonDecode(response.body);
 
       if (decoded is! Map<String, dynamic>) {
         throw UvApiException(response.statusCode, response.body);

--- a/lib/api/uv_api.dart
+++ b/lib/api/uv_api.dart
@@ -55,7 +55,10 @@ class UvApi {
 
     final Uri uri = Uri.parse(
       '$_proxyBaseUrl/api/uv',
-    ).replace(queryParameters: <String, dynamic>{'lat': lat.toString(), 'lon': lon.toString()});
+    ).replace(queryParameters: <String, dynamic>{
+      'lat': lat.toString(),
+      'lon': lon.toString(),
+    });
 
     // TODO(retry): add exponential backoff for TimeoutException
     //   and transient errors

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,7 +9,7 @@ Future<void> main() async {
     () async {
       WidgetsFlutterBinding.ensureInitialized();
 
-      FlutterError.onError = (details) {
+      FlutterError.onError = (FlutterErrorDetails details) {
         FlutterError.presentError(details);
         // TODO(crashes): forward to crash reporting
         // (e.g. Sentry, Firebase Crashlytics)
@@ -17,7 +17,7 @@ Future<void> main() async {
 
       runApp(const ProviderScope(child: UvAlertApp()));
     },
-    (error, stack) {
+    (Object error, StackTrace stack) {
       debugPrint('Unhandled async error: $error\n$stack');
       // TODO(crashes): forward to crash reporting
       // (e.g. Sentry, Firebase Crashlytics)

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -75,14 +75,16 @@ class UvData {
       sunrise: _fromEpochSeconds(current['sunrise'] as int),
       sunset: _fromEpochSeconds(current['sunset'] as int),
       clouds: (current['clouds'] as num).toInt(),
-      hourly: List.unmodifiable(
-        (json['hourly'] as List? ?? <dynamic>[]).map(
-          (h) => UvForecastEntry.fromJson(h as Map<String, dynamic>),
+      hourly: List<UvForecastEntry>.unmodifiable(
+        (json['hourly'] as List<dynamic>? ?? <dynamic>[]).map<UvForecastEntry>(
+          (dynamic h) =>
+              UvForecastEntry.fromJson(h as Map<String, dynamic>),
         ),
       ),
-      daily: List.unmodifiable(
-        (json['daily'] as List? ?? <dynamic>[]).map(
-          (d) => UvForecastEntry.fromJson(d as Map<String, dynamic>),
+      daily: List<UvForecastEntry>.unmodifiable(
+        (json['daily'] as List<dynamic>? ?? <dynamic>[]).map<UvForecastEntry>(
+          (dynamic d) =>
+              UvForecastEntry.fromJson(d as Map<String, dynamic>),
         ),
       ),
       timezone: json['timezone'] as String,

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -76,15 +76,13 @@ class UvData {
       sunset: _fromEpochSeconds(current['sunset']! as int),
       clouds: (current['clouds']! as num).toInt(),
       hourly: List<UvForecastEntry>.unmodifiable(
-        (json['hourly'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
-          (Object h) =>
-              UvForecastEntry.fromJson(h as Map<String, Object?>),
+        (json['hourly'] as List<dynamic>? ?? <Object>[]).map<UvForecastEntry>(
+          (dynamic h) => UvForecastEntry.fromJson(h as Map<String, Object?>),
         ),
       ),
       daily: List<UvForecastEntry>.unmodifiable(
-        (json['daily'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
-          (Object d) =>
-              UvForecastEntry.fromJson(d as Map<String, Object?>),
+        (json['daily'] as List<dynamic>? ?? <Object>[]).map<UvForecastEntry>(
+          (dynamic d) => UvForecastEntry.fromJson(d as Map<String, Object?>),
         ),
       ),
       timezone: json['timezone']! as String,

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -27,7 +27,7 @@ class UvForecastEntry {
   final double uvi;
 
   /// Serializes this entry to a JSON map.
-  Map<String, dynamic> toJson() => {'dt': _toEpochSeconds(time), 'uvi': uvi};
+  Map<String, dynamic> toJson() => <String, dynamic>{'dt': _toEpochSeconds(time), 'uvi': uvi};
 
   // Override == for value equality: two entries with identical time and uvi
   // are equal regardless of whether they are the same object in memory.
@@ -64,7 +64,7 @@ class UvData {
   ///
   /// Throws [FormatException] if the required `fetched_at` field is absent.
   factory UvData.fromJson(Map<String, dynamic> json) {
-    final current = json['current'] as Map<String, dynamic>;
+    final Map<String, dynamic> current = json['current'] as Map<String, dynamic>;
 
     return UvData(
       currentUvi: (current['uvi'] as num).toDouble(),
@@ -72,12 +72,12 @@ class UvData {
       sunset: _fromEpochSeconds(current['sunset'] as int),
       clouds: (current['clouds'] as num).toInt(),
       hourly: List.unmodifiable(
-        (json['hourly'] as List? ?? []).map(
+        (json['hourly'] as List? ?? <dynamic>[]).map(
           (h) => UvForecastEntry.fromJson(h as Map<String, dynamic>),
         ),
       ),
       daily: List.unmodifiable(
-        (json['daily'] as List? ?? []).map(
+        (json['daily'] as List? ?? <dynamic>[]).map(
           (d) => UvForecastEntry.fromJson(d as Map<String, dynamic>),
         ),
       ),
@@ -118,15 +118,15 @@ class UvData {
 
   /// Serializes this instance to a JSON map.
   Map<String, dynamic> toJson() {
-    return {
-      'current': {
+    return <String, dynamic>{
+      'current': <String, num>{
         'uvi': currentUvi,
         'sunrise': _toEpochSeconds(sunrise),
         'sunset': _toEpochSeconds(sunset),
         'clouds': clouds,
       },
-      'hourly': hourly.map((h) => h.toJson()).toList(),
-      'daily': daily.map((d) => d.toJson()).toList(),
+      'hourly': hourly.map((UvForecastEntry h) => h.toJson()).toList(),
+      'daily': daily.map((UvForecastEntry d) => d.toJson()).toList(),
       'timezone': timezone,
       'timezone_offset': timezoneOffset,
       'fetched_at': _toEpochSeconds(fetchedAt),
@@ -154,7 +154,7 @@ class UvData {
   // Override hashCode whenever == is overridden. Dart requires that objects
   // which are == produce the same hashCode, otherwise Sets and Maps break.
   @override
-  int get hashCode => Object.hashAll([
+  int get hashCode => Object.hashAll(<Object?>[
     currentUvi,
     sunrise,
     sunset,

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -27,7 +27,10 @@ class UvForecastEntry {
   final double uvi;
 
   /// Serializes this entry to a JSON map.
-  Map<String, dynamic> toJson() => <String, dynamic>{'dt': _toEpochSeconds(time), 'uvi': uvi};
+  Map<String, dynamic> toJson() => <String, dynamic>{
+    'dt': _toEpochSeconds(time),
+    'uvi': uvi,
+  };
 
   // Override == for value equality: two entries with identical time and uvi
   // are equal regardless of whether they are the same object in memory.
@@ -64,7 +67,8 @@ class UvData {
   ///
   /// Throws [FormatException] if the required `fetched_at` field is absent.
   factory UvData.fromJson(Map<String, dynamic> json) {
-    final Map<String, dynamic> current = json['current'] as Map<String, dynamic>;
+    final Map<String, dynamic> current =
+        json['current'] as Map<String, dynamic>;
 
     return UvData(
       currentUvi: (current['uvi'] as num).toDouble(),

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -13,10 +13,10 @@ class UvForecastEntry {
   const UvForecastEntry({required this.time, required this.uvi});
 
   /// Deserializes a [UvForecastEntry] from a JSON map.
-  factory UvForecastEntry.fromJson(Map<String, dynamic> json) {
+  factory UvForecastEntry.fromJson(Map<String, Object?> json) {
     return UvForecastEntry(
-      time: _fromEpochSeconds(json['dt'] as int),
-      uvi: (json['uvi'] as num).toDouble(),
+      time: _fromEpochSeconds(json['dt']! as int),
+      uvi: (json['uvi']! as num).toDouble(),
     );
   }
 
@@ -27,7 +27,7 @@ class UvForecastEntry {
   final double uvi;
 
   /// Serializes this entry to a JSON map.
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, Object?> toJson() => <String, Object?>{
     'dt': _toEpochSeconds(time),
     'uvi': uvi,
   };
@@ -66,31 +66,31 @@ class UvData {
   /// Deserializes a [UvData] from a JSON map.
   ///
   /// Throws [FormatException] if the required `fetched_at` field is absent.
-  factory UvData.fromJson(Map<String, dynamic> json) {
-    final Map<String, dynamic> current =
-        json['current'] as Map<String, dynamic>;
+  factory UvData.fromJson(Map<String, Object?> json) {
+    final Map<String, Object?> current =
+        json['current']! as Map<String, Object?>;
 
     return UvData(
-      currentUvi: (current['uvi'] as num).toDouble(),
-      sunrise: _fromEpochSeconds(current['sunrise'] as int),
-      sunset: _fromEpochSeconds(current['sunset'] as int),
-      clouds: (current['clouds'] as num).toInt(),
+      currentUvi: (current['uvi']! as num).toDouble(),
+      sunrise: _fromEpochSeconds(current['sunrise']! as int),
+      sunset: _fromEpochSeconds(current['sunset']! as int),
+      clouds: (current['clouds']! as num).toInt(),
       hourly: List<UvForecastEntry>.unmodifiable(
         (json['hourly'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
           (Object h) =>
-              UvForecastEntry.fromJson(h as Map<String, dynamic>),
+              UvForecastEntry.fromJson(h as Map<String, Object?>),
         ),
       ),
       daily: List<UvForecastEntry>.unmodifiable(
         (json['daily'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
           (Object d) =>
-              UvForecastEntry.fromJson(d as Map<String, dynamic>),
+              UvForecastEntry.fromJson(d as Map<String, Object?>),
         ),
       ),
-      timezone: json['timezone'] as String,
-      timezoneOffset: json['timezone_offset'] as int,
+      timezone: json['timezone']! as String,
+      timezoneOffset: json['timezone_offset']! as int,
       fetchedAt: json['fetched_at'] != null
-          ? _fromEpochSeconds(json['fetched_at'] as int)
+          ? _fromEpochSeconds(json['fetched_at']! as int)
           : throw const FormatException('missing required field: fetched_at'),
     );
   }
@@ -123,8 +123,8 @@ class UvData {
   final DateTime fetchedAt;
 
   /// Serializes this instance to a JSON map.
-  Map<String, dynamic> toJson() {
-    return <String, dynamic>{
+  Map<String, Object?> toJson() {
+    return <String, Object?>{
       'current': <String, num>{
         'uvi': currentUvi,
         'sunrise': _toEpochSeconds(sunrise),

--- a/lib/models/uv_model.dart
+++ b/lib/models/uv_model.dart
@@ -76,14 +76,14 @@ class UvData {
       sunset: _fromEpochSeconds(current['sunset'] as int),
       clouds: (current['clouds'] as num).toInt(),
       hourly: List<UvForecastEntry>.unmodifiable(
-        (json['hourly'] as List<dynamic>? ?? <dynamic>[]).map<UvForecastEntry>(
-          (dynamic h) =>
+        (json['hourly'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
+          (Object h) =>
               UvForecastEntry.fromJson(h as Map<String, dynamic>),
         ),
       ),
       daily: List<UvForecastEntry>.unmodifiable(
-        (json['daily'] as List<dynamic>? ?? <dynamic>[]).map<UvForecastEntry>(
-          (dynamic d) =>
+        (json['daily'] as List<Object>? ?? <Object>[]).map<UvForecastEntry>(
+          (Object d) =>
               UvForecastEntry.fromJson(d as Map<String, dynamic>),
         ),
       ),

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -11,7 +11,7 @@ class LocationNotifier extends Notifier<LocationState> {
 
   /// Requests GPS permission then acquires the current position.
   Future<void> fetchGps() async {
-    var permission = await Geolocator.checkPermission();
+    LocationPermission permission = await Geolocator.checkPermission();
 
     if (permission == LocationPermission.denied) {
       permission = await Geolocator.requestPermission();
@@ -22,7 +22,7 @@ class LocationNotifier extends Notifier<LocationState> {
       throw const PermissionDeniedException('Location permission denied.');
     }
 
-    final position = await Geolocator.getCurrentPosition(
+    final Position position = await Geolocator.getCurrentPosition(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.medium,
       ),

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -10,15 +10,22 @@ final NotifierProvider<LocationNotifier, LocationState> locationProvider =
 
 /// Manages location state.
 class LocationNotifier extends Notifier<LocationState> {
+  /// Creates a [LocationNotifier]; [platform] defaults to
+  /// [GeolocatorPlatform.instance] for production use.
+  LocationNotifier({GeolocatorPlatform? platform})
+    : _platform = platform ?? GeolocatorPlatform.instance;
+
+  final GeolocatorPlatform _platform;
+
   @override
   LocationState build() => null;
 
   /// Requests GPS permission then acquires the current position.
   Future<void> fetchGps() async {
-    LocationPermission permission = await Geolocator.checkPermission();
+    LocationPermission permission = await _platform.checkPermission();
 
     if (permission == LocationPermission.denied) {
-      permission = await Geolocator.requestPermission();
+      permission = await _platform.requestPermission();
     }
 
     if (permission == LocationPermission.deniedForever ||
@@ -26,7 +33,7 @@ class LocationNotifier extends Notifier<LocationState> {
       throw const PermissionDeniedException('Location permission denied.');
     }
 
-    final Position position = await Geolocator.getCurrentPosition(
+    final Position position = await _platform.getCurrentPosition(
       locationSettings: const LocationSettings(
         accuracy: LocationAccuracy.medium,
       ),

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -4,6 +4,10 @@ import 'package:geolocator/geolocator.dart';
 /// Latitude/longitude pair; `null` until a location is acquired.
 typedef LocationState = ({double lat, double lon})?;
 
+/// Riverpod provider for [LocationNotifier].
+final NotifierProvider<LocationNotifier, LocationState> locationProvider =
+    NotifierProvider<LocationNotifier, LocationState>(LocationNotifier.new);
+
 /// Manages location state.
 class LocationNotifier extends Notifier<LocationState> {
   @override

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:geolocator/geolocator.dart';
 
 /// Latitude/longitude pair; `null` until a location is acquired.
 typedef LocationState = ({double lat, double lon})?;
@@ -7,4 +8,28 @@ typedef LocationState = ({double lat, double lon})?;
 class LocationNotifier extends Notifier<LocationState> {
   @override
   LocationState build() => null;
+
+  /// Requests GPS permission then acquires the current position.
+  Future<void> fetchGps() async {
+    var permission = await Geolocator.checkPermission();
+
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+    }
+
+    if (permission == LocationPermission.deniedForever ||
+        permission == LocationPermission.denied) {
+      throw const PermissionDeniedException(
+        'Location permission denied.',
+      );
+    }
+
+    final position = await Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.medium,
+      ),
+    );
+
+    state = (lat: position.latitude, lon: position.longitude);
+  }
 }

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Latitude/longitude pair; `null` until a location is acquired.
+typedef LocationState = ({double lat, double lon})?;
+
+/// Manages location state.
+class LocationNotifier extends Notifier<LocationState> {
+  @override
+  LocationState build() => null;
+}

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -19,9 +19,7 @@ class LocationNotifier extends Notifier<LocationState> {
 
     if (permission == LocationPermission.deniedForever ||
         permission == LocationPermission.denied) {
-      throw const PermissionDeniedException(
-        'Location permission denied.',
-      );
+      throw const PermissionDeniedException('Location permission denied.');
     }
 
     final position = await Geolocator.getCurrentPosition(
@@ -31,5 +29,10 @@ class LocationNotifier extends Notifier<LocationState> {
     );
 
     state = (lat: position.latitude, lon: position.longitude);
+  }
+
+  /// Overrides state with manually supplied coordinates.
+  void setManual({required double lat, required double lon}) {
+    state = (lat: lat, lon: lon);
   }
 }

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -17,9 +17,9 @@ class Cache {
   /// Persists [data] to the cache, keying expiry on the server-provided
   /// [UvData.fetchedAt] timestamp.
   Future<void> store(UvData data) async {
-    final json = jsonEncode(data.toJson());
+    final String json = jsonEncode(data.toJson());
 
-    await Future.wait([
+    await Future.wait(<Future<void>>[
       _prefs.setCachedPayload(json),
       // Intentional: use server-provided fetchedAt, not DateTime.now().
       // If the server timestamp lags real time, the cache expires sooner than
@@ -32,7 +32,7 @@ class Cache {
   ///
   /// Clears the cache automatically on a corrupt or malformed payload.
   Future<UvData?> read() async {
-    final raw = _prefs.cachedPayload;
+    final String? raw = _prefs.cachedPayload;
 
     if (raw == null) return null;
 
@@ -58,7 +58,7 @@ class Cache {
   ///
   /// Returns `true` when no timestamp is stored or the timestamp is corrupt.
   bool get isStale {
-    final cachedAt = _prefs.cachedPayloadAt;
+    final String? cachedAt = _prefs.cachedPayloadAt;
 
     if (cachedAt == null) return true;
 

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -37,7 +37,7 @@ class Cache {
     if (raw == null) return null;
 
     try {
-      final decoded = jsonDecode(raw);
+      final dynamic decoded = jsonDecode(raw);
 
       if (decoded is! Map<String, dynamic>) {
         if (kDebugMode) debugPrint('Cache.read: unexpected payload shape');

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -39,7 +39,7 @@ class Cache {
     try {
       final Object? decoded = jsonDecode(raw);
 
-      if (decoded is! Map<String, dynamic>) {
+      if (decoded is! Map<String, Object?>) {
         if (kDebugMode) debugPrint('Cache.read: unexpected payload shape');
 
         await _prefs.clearCache();

--- a/lib/storage/cache.dart
+++ b/lib/storage/cache.dart
@@ -37,7 +37,7 @@ class Cache {
     if (raw == null) return null;
 
     try {
-      final dynamic decoded = jsonDecode(raw);
+      final Object? decoded = jsonDecode(raw);
 
       if (decoded is! Map<String, dynamic>) {
         if (kDebugMode) debugPrint('Cache.read: unexpected payload shape');

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -3,21 +3,21 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Typed, prefixed wrapper around [SharedPreferences] for app settings.
 class Preferences {
   Preferences._(this._prefs);
-  static const _prefix = 'uvalert_';
-  static const _keyFirstLaunch = '${_prefix}first_launch';
-  static const _keyUuid = '${_prefix}uuid';
-  static const _keyTheme = '${_prefix}theme';
-  static const _keyUseGps = '${_prefix}use_gps';
-  static const _keyManualLocation = '${_prefix}manual_location';
-  static const _keyNotificationsEnabled = '${_prefix}notifications_enabled';
-  static const _keyCachedPayload = '${_prefix}cached_payload';
-  static const _keyCachedPayloadAt = '${_prefix}cached_payload_at';
+  static const String _prefix = 'uvalert_';
+  static const String _keyFirstLaunch = '${_prefix}first_launch';
+  static const String _keyUuid = '${_prefix}uuid';
+  static const String _keyTheme = '${_prefix}theme';
+  static const String _keyUseGps = '${_prefix}use_gps';
+  static const String _keyManualLocation = '${_prefix}manual_location';
+  static const String _keyNotificationsEnabled = '${_prefix}notifications_enabled';
+  static const String _keyCachedPayload = '${_prefix}cached_payload';
+  static const String _keyCachedPayloadAt = '${_prefix}cached_payload_at';
 
   final SharedPreferences _prefs;
 
   /// Loads and returns a [Preferences] instance backed by [SharedPreferences].
   static Future<Preferences> load() async {
-    final prefs = await SharedPreferences.getInstance();
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
     return Preferences._(prefs);
   }
 
@@ -83,7 +83,7 @@ class Preferences {
   ///
   /// Throws [StateError] if either key cannot be removed.
   Future<void> clearCache() async {
-    final results = await Future.wait([
+    final List<bool> results = await Future.wait(<Future<bool>>[
       _prefs.remove(_keyCachedPayload),
       _prefs.remove(_keyCachedPayloadAt),
     ]);
@@ -95,13 +95,13 @@ class Preferences {
   ///
   /// Throws [StateError] if any key cannot be removed.
   Future<void> clearAll() async {
-    final keys = _prefs.getKeys().where((k) => k.startsWith(_prefix)).toList();
-    final results = await Future.wait<bool>(keys.map(_prefs.remove));
+    final List<String> keys = _prefs.getKeys().where((String k) => k.startsWith(_prefix)).toList();
+    final List<bool> results = await Future.wait<bool>(keys.map(_prefs.remove));
     _assertAllRemoved(results, 'clearAll');
   }
 
   void _assertAllRemoved(List<bool> results, String operation) {
-    if (results.any((ok) => !ok)) {
+    if (results.any((bool ok) => !ok)) {
       throw StateError('$operation: one or more keys could not be removed');
     }
   }

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -9,7 +9,8 @@ class Preferences {
   static const String _keyTheme = '${_prefix}theme';
   static const String _keyUseGps = '${_prefix}use_gps';
   static const String _keyManualLocation = '${_prefix}manual_location';
-  static const String _keyNotificationsEnabled = '${_prefix}notifications_enabled';
+  static const String _keyNotificationsEnabled =
+      '${_prefix}notifications_enabled';
   static const String _keyCachedPayload = '${_prefix}cached_payload';
   static const String _keyCachedPayloadAt = '${_prefix}cached_payload_at';
 
@@ -95,7 +96,10 @@ class Preferences {
   ///
   /// Throws [StateError] if any key cannot be removed.
   Future<void> clearAll() async {
-    final List<String> keys = _prefs.getKeys().where((String k) => k.startsWith(_prefix)).toList();
+    final List<String> keys = _prefs
+        .getKeys()
+        .where((String k) => k.startsWith(_prefix))
+        .toList();
     final List<bool> results = await Future.wait<bool>(keys.map(_prefs.remove));
     _assertAllRemoved(results, 'clearAll');
   }

--- a/test/cache_test.dart
+++ b/test/cache_test.dart
@@ -12,9 +12,9 @@ DateTime _staleTimestamp() =>
     DateTime.now().toUtc().subtract(const Duration(hours: _staleHours));
 
 UvData _makeData({DateTime? fetchedAt}) {
-  final raw = fetchedAt ?? DateTime.now().toUtc();
+  final DateTime raw = fetchedAt ?? DateTime.now().toUtc();
   // Truncate to whole seconds: epoch-seconds serialization has 1s precision.
-  final now = DateTime.fromMillisecondsSinceEpoch(
+  final DateTime now = DateTime.fromMillisecondsSinceEpoch(
     raw.millisecondsSinceEpoch - raw.millisecondsSinceEpoch % msPerSecond,
     isUtc: true,
   );
@@ -23,8 +23,8 @@ UvData _makeData({DateTime? fetchedAt}) {
     sunrise: now,
     sunset: now.add(const Duration(hours: 12)),
     clouds: 10,
-    hourly: const [],
-    daily: const [],
+    hourly: const <UvForecastEntry>[],
+    daily: const <UvForecastEntry>[],
     timezone: 'UTC',
     timezoneOffset: 0,
     fetchedAt: now,
@@ -36,7 +36,7 @@ void main() {
   late Cache cache;
 
   setUp(() async {
-    SharedPreferences.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues(<String, Object>{});
     prefs = await Preferences.load();
     cache = Cache(prefs);
   });
@@ -68,7 +68,7 @@ void main() {
     });
 
     test('is not stale when timestamp is TTL - 1 hours old', () async {
-      final recent = DateTime.now().toUtc().subtract(
+      final DateTime recent = DateTime.now().toUtc().subtract(
         const Duration(hours: _freshHours),
       );
       await cache.store(_makeData(fetchedAt: recent));
@@ -115,11 +115,11 @@ void main() {
     });
 
     test('returns stored data with matching fields', () async {
-      final data = _makeData();
+      final UvData data = _makeData();
 
       await cache.store(data);
 
-      final result = await cache.read();
+      final UvData? result = await cache.read();
 
       expect(result, isNotNull);
       expect(result!.currentUvi, data.currentUvi);
@@ -130,7 +130,7 @@ void main() {
     test('clears cache and returns null on corrupt payload', () async {
       await prefs.setCachedPayload('not valid json {{{');
 
-      final result = await cache.read();
+      final UvData? result = await cache.read();
 
       expect(result, isNull);
       expect(cache.isEmpty, isTrue);
@@ -141,7 +141,7 @@ void main() {
       () async {
         await prefs.setCachedPayload('[1, 2, 3]');
 
-        final result = await cache.read();
+        final UvData? result = await cache.read();
 
         expect(result, isNull);
         expect(cache.isEmpty, isTrue);
@@ -151,7 +151,7 @@ void main() {
 
   group('Cache store', () {
     test('stores payload and timestamp', () async {
-      final data = _makeData();
+      final UvData data = _makeData();
 
       await cache.store(data);
 
@@ -160,13 +160,13 @@ void main() {
     });
 
     test('overwrites previously stored data', () async {
-      final first = _makeData(fetchedAt: DateTime.utc(2023));
-      final second = _makeData(fetchedAt: DateTime.utc(2024));
+      final UvData first = _makeData(fetchedAt: DateTime.utc(2023));
+      final UvData second = _makeData(fetchedAt: DateTime.utc(2024));
 
       await cache.store(first);
       await cache.store(second);
 
-      final result = await cache.read();
+      final UvData? result = await cache.read();
 
       expect(result!.fetchedAt, second.fetchedAt);
     });

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -1,0 +1,177 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:geolocator/geolocator.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:uvalert/providers/location_provider.dart';
+
+// ---------------------------------------------------------------------------
+// Mocks
+//
+// GeolocatorPlatform is the abstract class that Geolocator.checkPermission(),
+// requestPermission(), and getCurrentPosition() all delegate to. By swapping
+// GeolocatorPlatform.instance with a Mock we intercept every GPS call without
+// touching real hardware.
+// ---------------------------------------------------------------------------
+
+// plugin_platform_interface requires that the mock *extends* GeolocatorPlatform
+// (not merely implements it), so we use `extends ... with Mock` rather than
+// `extends Mock implements ...`.
+class _MockGeolocatorPlatform extends GeolocatorPlatform with Mock {}
+
+// A helper that builds an isolated Riverpod container.
+// ProviderContainer is the non-Flutter equivalent of ProviderScope — no
+// widget tree required. We create a fresh one per test so state never leaks.
+ProviderContainer _makeContainer() => ProviderContainer();
+
+// Minimal Position with only the fields our code touches (lat/lon).
+Position _fakePosition({double lat = 1.0, double lon = 2.0}) => Position(
+  latitude: lat,
+  longitude: lon,
+  timestamp: DateTime.utc(2024),
+  accuracy: 0,
+  altitude: 0,
+  altitudeAccuracy: 0,
+  heading: 0,
+  headingAccuracy: 0,
+  speed: 0,
+  speedAccuracy: 0,
+);
+
+void main() {
+  late _MockGeolocatorPlatform mock;
+
+  setUp(() {
+    mock = _MockGeolocatorPlatform();
+    // Inject the mock so every Geolocator.* call hits our stub.
+    GeolocatorPlatform.instance = mock;
+  });
+
+  tearDown(() {
+    // Let Riverpod clean up subscriptions.
+    // Containers created in each test are disposed there.
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  test('initial state is null', () {
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    expect(container.read(locationProvider), isNull);
+  });
+
+  // -------------------------------------------------------------------------
+  // setManual
+  // -------------------------------------------------------------------------
+
+  test('setManual updates state with supplied coordinates', () {
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    container
+        .read(locationProvider.notifier)
+        .setManual(lat: 51.5, lon: -0.1);
+
+    final LocationState state = container.read(locationProvider);
+    expect(state, isNotNull);
+    expect(state!.lat, 51.5);
+    expect(state.lon, -0.1);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchGps — permission already granted
+  // -------------------------------------------------------------------------
+
+  test('fetchGps stores position when permission is already granted', () async {
+    when(
+      () => mock.checkPermission(),
+    ).thenAnswer((_) async => LocationPermission.always);
+
+    when(
+      () => mock.getCurrentPosition(
+        locationSettings: any(named: 'locationSettings'),
+      ),
+    ).thenAnswer((_) async => _fakePosition(lat: 10, lon: 20));
+
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    await container.read(locationProvider.notifier).fetchGps();
+
+    final LocationState state = container.read(locationProvider);
+    expect(state, isNotNull);
+    expect(state!.lat, 10.0);
+    expect(state.lon, 20.0);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchGps — permission initially denied then granted
+  // -------------------------------------------------------------------------
+
+  test('fetchGps requests permission when initially denied', () async {
+    when(
+      () => mock.checkPermission(),
+    ).thenAnswer((_) async => LocationPermission.denied);
+
+    when(
+      () => mock.requestPermission(),
+    ).thenAnswer((_) async => LocationPermission.whileInUse);
+
+    when(
+      () => mock.getCurrentPosition(
+        locationSettings: any(named: 'locationSettings'),
+      ),
+    ).thenAnswer((_) async => _fakePosition(lat: 3, lon: 4));
+
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    await container.read(locationProvider.notifier).fetchGps();
+
+    final LocationState state = container.read(locationProvider);
+    expect(state!.lat, 3.0);
+    expect(state.lon, 4.0);
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchGps — permission denied forever
+  // -------------------------------------------------------------------------
+
+  test('fetchGps throws PermissionDeniedException when denied forever', () {
+    when(
+      () => mock.checkPermission(),
+    ).thenAnswer((_) async => LocationPermission.deniedForever);
+
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    expect(
+      () => container.read(locationProvider.notifier).fetchGps(),
+      throwsA(isA<PermissionDeniedException>()),
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // fetchGps — request returns denied
+  // -------------------------------------------------------------------------
+
+  test('fetchGps throws PermissionDeniedException when request is denied', () {
+    when(
+      () => mock.checkPermission(),
+    ).thenAnswer((_) async => LocationPermission.denied);
+
+    when(
+      () => mock.requestPermission(),
+    ).thenAnswer((_) async => LocationPermission.denied);
+
+    final ProviderContainer container = _makeContainer();
+    addTearDown(container.dispose);
+
+    expect(
+      () => container.read(locationProvider.notifier).fetchGps(),
+      throwsA(isA<PermissionDeniedException>()),
+    );
+  });
+}

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -1,30 +1,37 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:uvalert/providers/location_provider.dart';
 
 // ---------------------------------------------------------------------------
-// Mocks
+// Fake GeolocatorPlatform
 //
-// GeolocatorPlatform is the abstract class that Geolocator.checkPermission(),
-// requestPermission(), and getCurrentPosition() all delegate to. By swapping
-// GeolocatorPlatform.instance with a Mock we intercept every GPS call without
-// touching real hardware.
+// plugin_platform_interface requires the mock to *extend* GeolocatorPlatform,
+// not merely implement it, so Mocktail cannot be used here. We use a hand-
+// rolled fake instead. Each field can be set per-test before fetchGps() runs.
 // ---------------------------------------------------------------------------
 
-// plugin_platform_interface requires that the mock *extends* GeolocatorPlatform
-// (not merely implements it), so we use `extends ... with Mock` rather than
-// `extends Mock implements ...`.
-class _MockGeolocatorPlatform extends GeolocatorPlatform with Mock {}
+class _FakePlatform extends GeolocatorPlatform {
+  LocationPermission checkResult = LocationPermission.always;
+  LocationPermission requestResult = LocationPermission.always;
+  Position? positionResult;
 
-// A helper that builds an isolated Riverpod container.
-// ProviderContainer is the non-Flutter equivalent of ProviderScope — no
-// widget tree required. We create a fresh one per test so state never leaks.
-ProviderContainer _makeContainer() => ProviderContainer();
+  @override
+  Future<LocationPermission> checkPermission() async => checkResult;
+
+  @override
+  Future<LocationPermission> requestPermission() async => requestResult;
+
+  @override
+  Future<Position> getCurrentPosition({
+    LocationSettings? locationSettings,
+  }) async {
+    return positionResult!;
+  }
+}
 
 // Minimal Position with only the fields our code touches (lat/lon).
-Position _fakePosition({double lat = 1.0, double lon = 2.0}) => Position(
+Position _fakePosition({double lat = 1, double lon = 2}) => Position(
   latitude: lat,
   longitude: lon,
   timestamp: DateTime.utc(2024),
@@ -37,26 +44,25 @@ Position _fakePosition({double lat = 1.0, double lon = 2.0}) => Position(
   speedAccuracy: 0,
 );
 
+// Builds a ProviderContainer with a LocationNotifier wired to the given fake.
+// Using `overrideWith` lets us inject a custom notifier instance while keeping
+// the rest of the Riverpod graph untouched.
+ProviderContainer _makeContainer(_FakePlatform platform) {
+  return ProviderContainer(
+    // ignore: always_specify_types — Override is not in flutter_riverpod's public API
+    overrides: [
+      locationProvider.overrideWith(() => LocationNotifier(platform: platform)),
+    ],
+  );
+}
+
 void main() {
-  late _MockGeolocatorPlatform mock;
-
-  setUp(() {
-    mock = _MockGeolocatorPlatform();
-    // Inject the mock so every Geolocator.* call hits our stub.
-    GeolocatorPlatform.instance = mock;
-  });
-
-  tearDown(() {
-    // Let Riverpod clean up subscriptions.
-    // Containers created in each test are disposed there.
-  });
-
   // -------------------------------------------------------------------------
   // Initial state
   // -------------------------------------------------------------------------
 
   test('initial state is null', () {
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(_FakePlatform());
     addTearDown(container.dispose);
 
     expect(container.read(locationProvider), isNull);
@@ -67,7 +73,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('setManual updates state with supplied coordinates', () {
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(_FakePlatform());
     addTearDown(container.dispose);
 
     container
@@ -85,25 +91,19 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('fetchGps stores position when permission is already granted', () async {
-    when(
-      () => mock.checkPermission(),
-    ).thenAnswer((_) async => LocationPermission.always);
+    final _FakePlatform platform = _FakePlatform()
+      ..checkResult = LocationPermission.always
+      ..positionResult = _fakePosition(lat: 10, lon: 20);
 
-    when(
-      () => mock.getCurrentPosition(
-        locationSettings: any(named: 'locationSettings'),
-      ),
-    ).thenAnswer((_) async => _fakePosition(lat: 10, lon: 20));
-
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
     await container.read(locationProvider.notifier).fetchGps();
 
     final LocationState state = container.read(locationProvider);
     expect(state, isNotNull);
-    expect(state!.lat, 10.0);
-    expect(state.lon, 20.0);
+    expect(state!.lat, 10);
+    expect(state.lon, 20);
   });
 
   // -------------------------------------------------------------------------
@@ -111,28 +111,19 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('fetchGps requests permission when initially denied', () async {
-    when(
-      () => mock.checkPermission(),
-    ).thenAnswer((_) async => LocationPermission.denied);
+    final _FakePlatform platform = _FakePlatform()
+      ..checkResult = LocationPermission.denied
+      ..requestResult = LocationPermission.whileInUse
+      ..positionResult = _fakePosition(lat: 3, lon: 4);
 
-    when(
-      () => mock.requestPermission(),
-    ).thenAnswer((_) async => LocationPermission.whileInUse);
-
-    when(
-      () => mock.getCurrentPosition(
-        locationSettings: any(named: 'locationSettings'),
-      ),
-    ).thenAnswer((_) async => _fakePosition(lat: 3, lon: 4));
-
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
     await container.read(locationProvider.notifier).fetchGps();
 
     final LocationState state = container.read(locationProvider);
-    expect(state!.lat, 3.0);
-    expect(state.lon, 4.0);
+    expect(state!.lat, 3);
+    expect(state.lon, 4);
   });
 
   // -------------------------------------------------------------------------
@@ -140,11 +131,10 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('fetchGps throws PermissionDeniedException when denied forever', () {
-    when(
-      () => mock.checkPermission(),
-    ).thenAnswer((_) async => LocationPermission.deniedForever);
+    final _FakePlatform platform = _FakePlatform()
+      ..checkResult = LocationPermission.deniedForever;
 
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
     expect(
@@ -158,15 +148,11 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('fetchGps throws PermissionDeniedException when request is denied', () {
-    when(
-      () => mock.checkPermission(),
-    ).thenAnswer((_) async => LocationPermission.denied);
+    final _FakePlatform platform = _FakePlatform()
+      ..checkResult = LocationPermission.denied
+      ..requestResult = LocationPermission.denied;
 
-    when(
-      () => mock.requestPermission(),
-    ).thenAnswer((_) async => LocationPermission.denied);
-
-    final ProviderContainer container = _makeContainer();
+    final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
     expect(

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -76,9 +76,7 @@ void main() {
     final ProviderContainer container = _makeContainer(_FakePlatform());
     addTearDown(container.dispose);
 
-    container
-        .read(locationProvider.notifier)
-        .setManual(lat: 51.5, lon: -0.1);
+    container.read(locationProvider.notifier).setManual(lat: 51.5, lon: -0.1);
 
     final LocationState state = container.read(locationProvider);
     expect(state, isNotNull);

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -128,15 +128,16 @@ void main() {
   // fetchGps — permission denied forever
   // -------------------------------------------------------------------------
 
-  test('fetchGps throws PermissionDeniedException when denied forever', () {
+  test('fetchGps throws PermissionDeniedException when denied forever',
+      () async {
     final _FakePlatform platform = _FakePlatform()
       ..checkResult = LocationPermission.deniedForever;
 
     final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
-    expect(
-      () => container.read(locationProvider.notifier).fetchGps(),
+    await expectLater(
+      container.read(locationProvider.notifier).fetchGps(),
       throwsA(isA<PermissionDeniedException>()),
     );
   });
@@ -145,7 +146,8 @@ void main() {
   // fetchGps — request returns denied
   // -------------------------------------------------------------------------
 
-  test('fetchGps throws PermissionDeniedException when request is denied', () {
+  test('fetchGps throws PermissionDeniedException when request is denied',
+      () async {
     final _FakePlatform platform = _FakePlatform()
       ..checkResult = LocationPermission.denied
       ..requestResult = LocationPermission.denied;
@@ -153,9 +155,37 @@ void main() {
     final ProviderContainer container = _makeContainer(platform);
     addTearDown(container.dispose);
 
-    expect(
-      () => container.read(locationProvider.notifier).fetchGps(),
+    await expectLater(
+      container.read(locationProvider.notifier).fetchGps(),
       throwsA(isA<PermissionDeniedException>()),
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // Default constructor — covers the ?? GeolocatorPlatform.instance fallback
+  // -------------------------------------------------------------------------
+
+  test('default constructor uses GeolocatorPlatform.instance', () async {
+    final _FakePlatform fake = _FakePlatform()
+      ..checkResult = LocationPermission.always
+      ..positionResult = _fakePosition(lat: 5, lon: 6);
+
+    final GeolocatorPlatform original = GeolocatorPlatform.instance;
+    GeolocatorPlatform.instance = fake;
+    addTearDown(() => GeolocatorPlatform.instance = original);
+
+    final ProviderContainer container = ProviderContainer(
+      // ignore: always_specify_types — Override is not in flutter_riverpod's public API
+      overrides: [
+        locationProvider.overrideWith(LocationNotifier.new),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await container.read(locationProvider.notifier).fetchGps();
+
+    final LocationState state = container.read(locationProvider);
+    expect(state!.lat, 5);
+    expect(state.lon, 6);
   });
 }

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -26,6 +26,9 @@ class _FakePlatform extends GeolocatorPlatform {
   Future<Position> getCurrentPosition({
     LocationSettings? locationSettings,
   }) async {
+    if (positionResult == null) {
+      throw StateError('_FakePlatform: positionResult not set for this test');
+    }
     return positionResult!;
   }
 }

--- a/test/preferences_test.dart
+++ b/test/preferences_test.dart
@@ -12,90 +12,90 @@ class _FailingRemoveStore extends InMemorySharedPreferencesStore {
 
 void main() {
   setUp(() {
-    SharedPreferences.setMockInitialValues({});
+    SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
   group('Preferences defaults', () {
     test('isFirstLaunch is true when no value stored', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.isFirstLaunch, isTrue);
     });
 
     test('theme defaults to system', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.theme, 'system');
     });
 
     test('useGps defaults to true', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.useGps, isTrue);
     });
 
     test('notificationsEnabled defaults to false', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.notificationsEnabled, isFalse);
     });
 
     test('uuid is null when not set', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.uuid, isNull);
     });
 
     test('cachedPayload is null when not set', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.cachedPayload, isNull);
     });
 
     test('cachedPayloadAt is null when not set', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.cachedPayloadAt, isNull);
     });
 
     test('manualLocation is null when not set', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.manualLocation, isNull);
     });
   });
 
   group('Preferences setters', () {
     test('setFirstLaunchDone sets isFirstLaunch to false', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setFirstLaunchDone();
       expect(prefs.isFirstLaunch, isFalse);
     });
 
     test('setUuid stores and retrieves uuid', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setUuid('abc-123');
       expect(prefs.uuid, 'abc-123');
     });
 
     test('setTheme stores and retrieves theme', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setTheme('dark');
       expect(prefs.theme, 'dark');
     });
 
     test('setUseGps toggles value', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setUseGps(value: false);
       expect(prefs.useGps, isFalse);
     });
 
     test('setManualLocation stores and retrieves location', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setManualLocation('New York, NY');
       expect(prefs.manualLocation, 'New York, NY');
     });
 
     test('setNotificationsEnabled stores and retrieves value', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setNotificationsEnabled(value: true);
       expect(prefs.notificationsEnabled, isTrue);
     });
 
     test('setCachedPayload and setCachedPayloadAt store values', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setCachedPayload('{"foo": 1}');
       await prefs.setCachedPayloadAt('2023-11-14T12:00:00.000Z');
       expect(prefs.cachedPayload, '{"foo": 1}');
@@ -105,7 +105,7 @@ void main() {
 
   group('Preferences clearCache', () {
     test('clearCache removes cached payload and timestamp', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setCachedPayload('data');
       await prefs.setCachedPayloadAt('2023-11-14T12:00:00.000Z');
       await prefs.clearCache();
@@ -114,7 +114,7 @@ void main() {
     });
 
     test('clearCache does not affect other preferences', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setUuid('keep-me');
       await prefs.clearCache();
       expect(prefs.uuid, 'keep-me');
@@ -127,12 +127,12 @@ void main() {
     });
 
     test('clearCache throws StateError when a key cannot be removed', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       expect(prefs.clearCache, throwsStateError);
     });
 
     test('clearAll throws StateError when a key cannot be removed', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setUuid('x');
       expect(prefs.clearAll, throwsStateError);
     });
@@ -140,7 +140,7 @@ void main() {
 
   group('Preferences clearAll', () {
     test('clearAll resets all values to defaults', () async {
-      final prefs = await Preferences.load();
+      final Preferences prefs = await Preferences.load();
       await prefs.setUuid('abc');
       await prefs.setTheme('dark');
       await prefs.setUseGps(value: false);

--- a/test/uv_api_test.dart
+++ b/test/uv_api_test.dart
@@ -22,15 +22,15 @@ UvData _makeData() => UvData(
   sunrise: DateTime.utc(2023, 11, 14, 6),
   sunset: DateTime.utc(2023, 11, 14, 18),
   clouds: 0,
-  hourly: const [],
-  daily: const [],
+  hourly: const <UvForecastEntry>[],
+  daily: const <UvForecastEntry>[],
   timezone: 'UTC',
   timezoneOffset: 0,
   fetchedAt: DateTime.utc(2023, 11, 14, 12),
 );
 
-Map<String, dynamic> _apiJson() => {
-  'current': {
+Map<String, dynamic> _apiJson() => <String, dynamic>{
+  'current': <String, num>{
     'uvi': 5.0,
     'sunrise': 1699945200,
     'sunset': 1699988400,
@@ -60,13 +60,13 @@ void main() {
 
   group('UvApi.fetch — cache hit', () {
     test('returns cached data without making a network request', () async {
-      final cached = _makeData();
+      final UvData cached = _makeData();
       when(() => mockCache.isValid).thenReturn(true);
       when(() => mockCache.read()).thenAnswer((_) async => cached);
 
-      final api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
+      final UvApi api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
 
-      final result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
 
       expect(result.currentUvi, cached.currentUvi);
       verifyNever(() => mockCache.store(any()));
@@ -78,13 +78,13 @@ void main() {
       when(() => mockCache.read()).thenAnswer((_) async => null);
       when(() => mockCache.store(any())).thenAnswer((_) async {});
 
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
         httpClient: _clientReturning(200, _apiJson()),
       );
 
-      final result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
 
       expect(result.currentUvi, 5.0);
       verify(() => mockCache.store(any())).called(1);
@@ -98,35 +98,35 @@ void main() {
     });
 
     test('fetches from network and stores result in cache', () async {
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
         httpClient: _clientReturning(200, _apiJson()),
       );
 
-      final result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
 
       expect(result.currentUvi, 5.0);
       verify(() => mockCache.store(any())).called(1);
     });
 
     test('throws UvApiException on non-200 response', () async {
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
-        httpClient: _clientReturning(500, {'error': 'server error'}),
+        httpClient: _clientReturning(500, <String, dynamic>{'error': 'server error'}),
       );
 
       await expectLater(
         () => api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1'),
         throwsA(
-          isA<UvApiException>().having((e) => e.statusCode, 'statusCode', 500),
+          isA<UvApiException>().having((UvApiException e) => e.statusCode, 'statusCode', 500),
         ),
       );
     });
 
     test('throws UvApiException on malformed JSON body', () async {
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
         httpClient: MockClient((_) async => http.Response('not json', 200)),
@@ -139,8 +139,8 @@ void main() {
     });
 
     test('throws UvApiException when JSON is not an object', () async {
-      for (final body in ['[1,2,3]', '"a string"', '42']) {
-        final api = UvApi(
+      for (final String body in <String>['[1,2,3]', '"a string"', '42']) {
+        final UvApi api = UvApi(
           cache: mockCache,
           proxyBaseUrl: 'http://example.com',
           httpClient: MockClient((_) async => http.Response(body, 200)),
@@ -157,10 +157,10 @@ void main() {
     test('sends correct lat/lon query parameters', () async {
       Uri? capturedUri;
 
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
-        httpClient: MockClient((request) async {
+        httpClient: MockClient((http.Request request) async {
           capturedUri = request.url;
           return http.Response(jsonEncode(_apiJson()), 200);
         }),
@@ -175,10 +175,10 @@ void main() {
     test('strips trailing slash from proxyBaseUrl', () async {
       Uri? capturedUri;
 
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com/',
-        httpClient: MockClient((request) async {
+        httpClient: MockClient((http.Request request) async {
           capturedUri = request.url;
           return http.Response(jsonEncode(_apiJson()), 200);
         }),
@@ -192,10 +192,10 @@ void main() {
     test('sends X-Device-ID header with uuid', () async {
       String? deviceId;
 
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
-        httpClient: MockClient((request) async {
+        httpClient: MockClient((http.Request request) async {
           deviceId = request.headers['X-Device-ID'];
           return http.Response(jsonEncode(_apiJson()), 200);
         }),
@@ -207,7 +207,7 @@ void main() {
     });
 
     test('propagates TimeoutException when request exceeds timeout', () async {
-      final api = UvApi(
+      final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
         timeout: const Duration(milliseconds: 1),
@@ -226,13 +226,13 @@ void main() {
       // httpClient omitted → _ownsClient = true; dispose() calls close() on
       // the internally created client. We can't intercept that client, so we
       // just confirm dispose() does not throw.
-      final api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
+      final UvApi api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
 
       expect(api.dispose, returnsNormally);
     });
 
     test('does not close the client when UvApi does not own it', () {
-      final client = MockHttpClient();
+      final MockHttpClient client = MockHttpClient();
 
       UvApi(
         cache: mockCache,
@@ -247,7 +247,7 @@ void main() {
 
   group('UvApiException', () {
     test('toString includes status code and body', () {
-      final e = UvApiException(404, 'not found');
+      final UvApiException e = UvApiException(404, 'not found');
       expect(e.toString(), contains('404'));
       expect(e.toString(), contains('not found'));
     });

--- a/test/uv_api_test.dart
+++ b/test/uv_api_test.dart
@@ -64,9 +64,16 @@ void main() {
       when(() => mockCache.isValid).thenReturn(true);
       when(() => mockCache.read()).thenAnswer((_) async => cached);
 
-      final UvApi api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
+      final UvApi api = UvApi(
+        cache: mockCache,
+        proxyBaseUrl: 'http://example.com',
+      );
 
-      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(
+        lat: 40.7,
+        lon: -74,
+        uuid: 'uuid-1',
+      );
 
       expect(result.currentUvi, cached.currentUvi);
       verifyNever(() => mockCache.store(any()));
@@ -84,7 +91,11 @@ void main() {
         httpClient: _clientReturning(200, _apiJson()),
       );
 
-      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(
+        lat: 40.7,
+        lon: -74,
+        uuid: 'uuid-1',
+      );
 
       expect(result.currentUvi, 5.0);
       verify(() => mockCache.store(any())).called(1);
@@ -104,7 +115,11 @@ void main() {
         httpClient: _clientReturning(200, _apiJson()),
       );
 
-      final UvData result = await api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1');
+      final UvData result = await api.fetch(
+        lat: 40.7,
+        lon: -74,
+        uuid: 'uuid-1',
+      );
 
       expect(result.currentUvi, 5.0);
       verify(() => mockCache.store(any())).called(1);
@@ -114,13 +129,19 @@ void main() {
       final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
-        httpClient: _clientReturning(500, <String, dynamic>{'error': 'server error'}),
+        httpClient: _clientReturning(500, <String, dynamic>{
+          'error': 'server error',
+        }),
       );
 
       await expectLater(
         () => api.fetch(lat: 40.7, lon: -74, uuid: 'uuid-1'),
         throwsA(
-          isA<UvApiException>().having((UvApiException e) => e.statusCode, 'statusCode', 500),
+          isA<UvApiException>().having(
+            (UvApiException e) => e.statusCode,
+            'statusCode',
+            500,
+          ),
         ),
       );
     });
@@ -226,7 +247,10 @@ void main() {
       // httpClient omitted → _ownsClient = true; dispose() calls close() on
       // the internally created client. We can't intercept that client, so we
       // just confirm dispose() does not throw.
-      final UvApi api = UvApi(cache: mockCache, proxyBaseUrl: 'http://example.com');
+      final UvApi api = UvApi(
+        cache: mockCache,
+        proxyBaseUrl: 'http://example.com',
+      );
 
       expect(api.dispose, returnsNormally);
     });

--- a/test/uv_api_test.dart
+++ b/test/uv_api_test.dart
@@ -29,21 +29,21 @@ UvData _makeData() => UvData(
   fetchedAt: DateTime.utc(2023, 11, 14, 12),
 );
 
-Map<String, dynamic> _apiJson() => <String, dynamic>{
+Map<String, Object?> _apiJson() => <String, Object?>{
   'current': <String, num>{
     'uvi': 5.0,
     'sunrise': 1699945200,
     'sunset': 1699988400,
     'clouds': 0,
   },
-  'hourly': <Map<String, dynamic>>[],
-  'daily': <Map<String, dynamic>>[],
+  'hourly': <Map<String, Object?>>[],
+  'daily': <Map<String, Object?>>[],
   'timezone': 'UTC',
   'timezone_offset': 0,
   'fetched_at': 1699963200,
 };
 
-http.Client _clientReturning(int status, Map<String, dynamic> body) {
+http.Client _clientReturning(int status, Map<String, Object?> body) {
   return MockClient((_) async => http.Response(jsonEncode(body), status));
 }
 
@@ -129,7 +129,7 @@ void main() {
       final UvApi api = UvApi(
         cache: mockCache,
         proxyBaseUrl: 'http://example.com',
-        httpClient: _clientReturning(500, <String, dynamic>{
+        httpClient: _clientReturning(500, <String, Object?>{
           'error': 'server error',
         }),
       );

--- a/test/uv_model_test.dart
+++ b/test/uv_model_test.dart
@@ -5,7 +5,7 @@ const int _secondsPerHour = 3600;
 const int _utcMinus5OffsetSeconds = -5 * _secondsPerHour;
 
 void main() {
-  final Map<String, dynamic> sampleJson = <String, dynamic>{
+  final Map<String, Object?> sampleJson = <String, Object?>{
     'current': <String, num>{
       'uvi': 7.5,
       'sunrise': 1700000000,
@@ -27,11 +27,11 @@ void main() {
   group('UvForecastEntry', () {
     test('equal when time and uvi match', () {
       final UvForecastEntry a = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+        const <String, Object?>{'dt': 1700010000, 'uvi': 5.0},
       );
 
       final UvForecastEntry b = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+        const <String, Object?>{'dt': 1700010000, 'uvi': 5.0},
       );
 
       expect(a, equals(b));
@@ -40,11 +40,11 @@ void main() {
 
     test('not equal when fields differ', () {
       final UvForecastEntry a = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+        const <String, Object?>{'dt': 1700010000, 'uvi': 5.0},
       );
 
       final UvForecastEntry b = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700010000, 'uvi': 6.0},
+        const <String, Object?>{'dt': 1700010000, 'uvi': 6.0},
       );
 
       expect(a, isNot(equals(b)));
@@ -52,10 +52,10 @@ void main() {
 
     test('fromJson round-trips through toJson', () {
       final UvForecastEntry entry = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+        const <String, Object?>{'dt': 1700010000, 'uvi': 5.0},
       );
 
-      final Map<String, dynamic> json = entry.toJson();
+      final Map<String, Object?> json = entry.toJson();
       final UvForecastEntry restored = UvForecastEntry.fromJson(json);
 
       expect(restored.uvi, entry.uvi);
@@ -64,14 +64,14 @@ void main() {
 
     test('parses epoch seconds into UTC DateTime', () {
       final UvForecastEntry entry = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 0, 'uvi': 1.0},
+        const <String, Object?>{'dt': 0, 'uvi': 1.0},
       );
       expect(entry.time, DateTime.utc(1970));
     });
 
     test('accepts integer uvi', () {
       final UvForecastEntry entry = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 1700000000, 'uvi': 3},
+        const <String, Object?>{'dt': 1700000000, 'uvi': 3},
       );
 
       expect(entry.uvi, 3.0);
@@ -93,14 +93,14 @@ void main() {
     });
 
     test('fromJson throws FormatException when fetched_at is absent', () {
-      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)
+      final Map<String, Object?> json = Map<String, Object?>.from(sampleJson)
         ..remove('fetched_at');
 
       expect(() => UvData.fromJson(json), throwsA(isA<FormatException>()));
     });
 
     test('fromJson handles missing hourly/daily lists', () {
-      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)
+      final Map<String, Object?> json = Map<String, Object?>.from(sampleJson)
         ..remove('hourly')
         ..remove('daily');
 
@@ -113,7 +113,7 @@ void main() {
     test('hourly and daily lists are unmodifiable', () {
       final UvData data = UvData.fromJson(sampleJson);
       final UvForecastEntry extra = UvForecastEntry.fromJson(
-        const <String, dynamic>{'dt': 0, 'uvi': 0.0},
+        const <String, Object?>{'dt': 0, 'uvi': 0.0},
       );
 
       expect(() => data.hourly.add(extra), throwsUnsupportedError);
@@ -130,7 +130,7 @@ void main() {
 
     test('not equal when a field differs', () {
       final UvData a = UvData.fromJson(sampleJson);
-      final UvData b = UvData.fromJson(<String, dynamic>{
+      final UvData b = UvData.fromJson(<String, Object?>{
         ...sampleJson,
         'timezone': 'America/Chicago',
       });

--- a/test/uv_model_test.dart
+++ b/test/uv_model_test.dart
@@ -26,27 +26,34 @@ void main() {
 
   group('UvForecastEntry', () {
     test('equal when time and uvi match', () {
-      final UvForecastEntry a = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry a = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+      );
 
-      final UvForecastEntry b = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry b = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+      );
 
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
 
     test('not equal when fields differ', () {
-      final UvForecastEntry a = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry a = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+      );
 
-      final UvForecastEntry b = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 6.0});
+      final UvForecastEntry b = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700010000, 'uvi': 6.0},
+      );
 
       expect(a, isNot(equals(b)));
     });
 
     test('fromJson round-trips through toJson', () {
-      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{
-        'dt': 1700010000,
-        'uvi': 5.0,
-      });
+      final UvForecastEntry entry = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0},
+      );
 
       final Map<String, dynamic> json = entry.toJson();
       final UvForecastEntry restored = UvForecastEntry.fromJson(json);
@@ -56,15 +63,16 @@ void main() {
     });
 
     test('parses epoch seconds into UTC DateTime', () {
-      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 0, 'uvi': 1.0});
+      final UvForecastEntry entry = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 0, 'uvi': 1.0},
+      );
       expect(entry.time, DateTime.utc(1970));
     });
 
     test('accepts integer uvi', () {
-      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{
-        'dt': 1700000000,
-        'uvi': 3,
-      });
+      final UvForecastEntry entry = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 1700000000, 'uvi': 3},
+      );
 
       expect(entry.uvi, 3.0);
     });
@@ -85,7 +93,8 @@ void main() {
     });
 
     test('fromJson throws FormatException when fetched_at is absent', () {
-      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)..remove('fetched_at');
+      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)
+        ..remove('fetched_at');
 
       expect(() => UvData.fromJson(json), throwsA(isA<FormatException>()));
     });
@@ -103,7 +112,9 @@ void main() {
 
     test('hourly and daily lists are unmodifiable', () {
       final UvData data = UvData.fromJson(sampleJson);
-      final UvForecastEntry extra = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 0, 'uvi': 0.0});
+      final UvForecastEntry extra = UvForecastEntry.fromJson(
+        const <String, dynamic>{'dt': 0, 'uvi': 0.0},
+      );
 
       expect(() => data.hourly.add(extra), throwsUnsupportedError);
       expect(data.daily.clear, throwsUnsupportedError);
@@ -119,7 +130,10 @@ void main() {
 
     test('not equal when a field differs', () {
       final UvData a = UvData.fromJson(sampleJson);
-      final UvData b = UvData.fromJson(<String, dynamic>{...sampleJson, 'timezone': 'America/Chicago'});
+      final UvData b = UvData.fromJson(<String, dynamic>{
+        ...sampleJson,
+        'timezone': 'America/Chicago',
+      });
 
       expect(a, isNot(equals(b)));
     });

--- a/test/uv_model_test.dart
+++ b/test/uv_model_test.dart
@@ -5,19 +5,19 @@ const int _secondsPerHour = 3600;
 const int _utcMinus5OffsetSeconds = -5 * _secondsPerHour;
 
 void main() {
-  final sampleJson = <String, dynamic>{
-    'current': {
+  final Map<String, dynamic> sampleJson = <String, dynamic>{
+    'current': <String, num>{
       'uvi': 7.5,
       'sunrise': 1700000000,
       'sunset': 1700050000,
       'clouds': 20,
     },
-    'hourly': [
-      {'dt': 1700010000, 'uvi': 5.0},
-      {'dt': 1700020000, 'uvi': 8.2},
+    'hourly': <Map<String, num>>[
+      <String, num>{'dt': 1700010000, 'uvi': 5.0},
+      <String, num>{'dt': 1700020000, 'uvi': 8.2},
     ],
-    'daily': [
-      {'dt': 1700000000, 'uvi': 9.1},
+    'daily': <Map<String, num>>[
+      <String, num>{'dt': 1700000000, 'uvi': 9.1},
     ],
     'timezone': 'America/New_York',
     'timezone_offset': _utcMinus5OffsetSeconds,
@@ -26,42 +26,42 @@ void main() {
 
   group('UvForecastEntry', () {
     test('equal when time and uvi match', () {
-      final a = UvForecastEntry.fromJson(const {'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry a = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
 
-      final b = UvForecastEntry.fromJson(const {'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry b = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
 
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
 
     test('not equal when fields differ', () {
-      final a = UvForecastEntry.fromJson(const {'dt': 1700010000, 'uvi': 5.0});
+      final UvForecastEntry a = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 5.0});
 
-      final b = UvForecastEntry.fromJson(const {'dt': 1700010000, 'uvi': 6.0});
+      final UvForecastEntry b = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 1700010000, 'uvi': 6.0});
 
       expect(a, isNot(equals(b)));
     });
 
     test('fromJson round-trips through toJson', () {
-      final entry = UvForecastEntry.fromJson(const {
+      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{
         'dt': 1700010000,
         'uvi': 5.0,
       });
 
-      final json = entry.toJson();
-      final restored = UvForecastEntry.fromJson(json);
+      final Map<String, dynamic> json = entry.toJson();
+      final UvForecastEntry restored = UvForecastEntry.fromJson(json);
 
       expect(restored.uvi, entry.uvi);
       expect(restored.time, entry.time);
     });
 
     test('parses epoch seconds into UTC DateTime', () {
-      final entry = UvForecastEntry.fromJson(const {'dt': 0, 'uvi': 1.0});
+      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 0, 'uvi': 1.0});
       expect(entry.time, DateTime.utc(1970));
     });
 
     test('accepts integer uvi', () {
-      final entry = UvForecastEntry.fromJson(const {
+      final UvForecastEntry entry = UvForecastEntry.fromJson(const <String, dynamic>{
         'dt': 1700000000,
         'uvi': 3,
       });
@@ -72,7 +72,7 @@ void main() {
 
   group('UvData', () {
     test('fromJson parses all fields correctly', () {
-      final data = UvData.fromJson(sampleJson);
+      final UvData data = UvData.fromJson(sampleJson);
 
       expect(data.currentUvi, 7.5);
       expect(data.clouds, 20);
@@ -85,48 +85,48 @@ void main() {
     });
 
     test('fromJson throws FormatException when fetched_at is absent', () {
-      final json = Map<String, dynamic>.from(sampleJson)..remove('fetched_at');
+      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)..remove('fetched_at');
 
       expect(() => UvData.fromJson(json), throwsA(isA<FormatException>()));
     });
 
     test('fromJson handles missing hourly/daily lists', () {
-      final json = Map<String, dynamic>.from(sampleJson)
+      final Map<String, dynamic> json = Map<String, dynamic>.from(sampleJson)
         ..remove('hourly')
         ..remove('daily');
 
-      final data = UvData.fromJson(json);
+      final UvData data = UvData.fromJson(json);
 
       expect(data.hourly, isEmpty);
       expect(data.daily, isEmpty);
     });
 
     test('hourly and daily lists are unmodifiable', () {
-      final data = UvData.fromJson(sampleJson);
-      final extra = UvForecastEntry.fromJson(const {'dt': 0, 'uvi': 0.0});
+      final UvData data = UvData.fromJson(sampleJson);
+      final UvForecastEntry extra = UvForecastEntry.fromJson(const <String, dynamic>{'dt': 0, 'uvi': 0.0});
 
       expect(() => data.hourly.add(extra), throwsUnsupportedError);
       expect(data.daily.clear, throwsUnsupportedError);
     });
 
     test('equal when all fields match', () {
-      final a = UvData.fromJson(sampleJson);
-      final b = UvData.fromJson(sampleJson);
+      final UvData a = UvData.fromJson(sampleJson);
+      final UvData b = UvData.fromJson(sampleJson);
 
       expect(a, equals(b));
       expect(a.hashCode, equals(b.hashCode));
     });
 
     test('not equal when a field differs', () {
-      final a = UvData.fromJson(sampleJson);
-      final b = UvData.fromJson({...sampleJson, 'timezone': 'America/Chicago'});
+      final UvData a = UvData.fromJson(sampleJson);
+      final UvData b = UvData.fromJson(<String, dynamic>{...sampleJson, 'timezone': 'America/Chicago'});
 
       expect(a, isNot(equals(b)));
     });
 
     test('toJson round-trips through fromJson', () {
-      final original = UvData.fromJson(sampleJson);
-      final restored = UvData.fromJson(original.toJson());
+      final UvData original = UvData.fromJson(sampleJson);
+      final UvData restored = UvData.fromJson(original.toJson());
 
       expect(restored.currentUvi, original.currentUvi);
       expect(restored.clouds, original.clouds);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:uvalert/app.dart';
 
 void main() {
-  testWidgets('UvAlertApp renders without error', (tester) async {
+  testWidgets('UvAlertApp renders without error', (WidgetTester tester) async {
     await tester.pumpWidget(const ProviderScope(child: UvAlertApp()));
     expect(find.byType(UvAlertApp), findsOneWidget);
   });


### PR DESCRIPTION
Closes #10

## Features

- Added `LocationNotifier` for managing location state with GPS and manual location support
- Added `fetchGps` method to `LocationNotifier` for acquiring GPS coordinates
- Added `setManual` method to `LocationNotifier` for manual location setting
- Added `locationProvider` for managing location state via Riverpod
- Implemented platform abstraction in `LocationNotifier` for GPS methods

## Bug Fixes

- Fixed `ClassCastException` in `UvData.fromJson` when parsing hourly and daily lists

## Type Safety

- Tightened type annotations throughout `UvApi`, `Cache`, `Preferences`, `LocationNotifier`, and tests
- Changed `dynamic` to `Object?` in `jsonDecode` calls, query parameters, and JSON serialization
- Specified `List<UvForecastEntry>` for `hourly` and `daily` fields in `UvData`

## Tests

- Fixed async exception tests and added default constructor coverage

## Linting

- Enabled `always_specify_types` to force explicit types instead of implicit dynamic
- Explicitly disabled `omit_local_variable_types` and `avoid_types_on_closure_parameters` (incompatible with `always_specify_types`)
- Removed redundant `avoid_types_on_closure_parameters: ignore` entry from `analyzer.errors` (already disabled via `linter.rules`)

## Style

- Formatted `UvApi`, `Preferences`, `UvForecastEntry`, `UvData`, and test files for consistency
- Improved type annotations for `FlutterError.onError` and zone error handler