### PR TITLE
feat: implement SettingsNotifier provider

### DIFF
--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -19,4 +19,22 @@ class SettingsState {
 
   /// Whether push notifications are enabled.
   final bool notificationsEnabled;
+
+  /// Returns a copy of this state with the given fields replaced.
+  SettingsState copyWith({
+    String? theme,
+    bool? useGps,
+    String? manualLocation,
+    bool? notificationsEnabled,
+    bool clearManualLocation = false,
+  }) {
+    return SettingsState(
+      theme: theme ?? this.theme,
+      useGps: useGps ?? this.useGps,
+      manualLocation: clearManualLocation
+          ? null
+          : (manualLocation ?? this.manualLocation),
+      notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
+    );
+  }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -135,7 +135,7 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
     await prefs.setNotificationsEnabled(value: value);
 
     if (!ref.mounted) return;
-    
+
     state = AsyncValue<SettingsState>.data(
       current.copyWith(notificationsEnabled: value),
     );

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -83,4 +83,45 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
     );
     return const AsyncValue<SettingsState>.loading();
   }
+
+  /// Sets the active theme and persists it to preferences.
+  Future<void> setTheme(String theme) async {
+    final Preferences prefs = await ref.read(preferencesProvider.future);
+    await prefs.setTheme(theme);
+    if (!ref.mounted) return;
+    state = AsyncValue<SettingsState>.data(
+      state.requireValue.copyWith(theme: theme),
+    );
+  }
+
+  /// Sets whether GPS location is enabled and persists it to preferences.
+  Future<void> setUseGps({required bool value}) async {
+    final Preferences prefs = await ref.read(preferencesProvider.future);
+    await prefs.setUseGps(value: value);
+    if (!ref.mounted) return;
+    state = AsyncValue<SettingsState>.data(
+      state.requireValue.copyWith(useGps: value),
+    );
+  }
+
+  /// Sets the manual location string and persists it to preferences.
+  Future<void> setManualLocation(String location) async {
+    final Preferences prefs = await ref.read(preferencesProvider.future);
+    await prefs.setManualLocation(location);
+    if (!ref.mounted) return;
+    state = AsyncValue<SettingsState>.data(
+      state.requireValue.copyWith(manualLocation: location),
+    );
+  }
+
+  /// Sets whether push notifications are enabled and persists it to
+  /// preferences.
+  Future<void> setNotificationsEnabled({required bool value}) async {
+    final Preferences prefs = await ref.read(preferencesProvider.future);
+    await prefs.setNotificationsEnabled(value: value);
+    if (!ref.mounted) return;
+    state = AsyncValue<SettingsState>.data(
+      state.requireValue.copyWith(notificationsEnabled: value),
+    );
+  }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -27,6 +27,10 @@ class SettingsState {
   final bool notificationsEnabled;
 
   /// Returns a copy of this state with the given fields replaced.
+  ///
+  /// [manualLocation] defaults to the current value when omitted. To represent
+  /// "not set", pass `null` only at construction time -- this method cannot
+  /// clear [manualLocation] back to `null` once a value has been stored.
   SettingsState copyWith({
     String? theme,
     bool? useGps,

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,0 +1,22 @@
+/// Holds the user-facing settings state.
+class SettingsState {
+  /// Creates a [SettingsState] with all fields required.
+  const SettingsState({
+    required this.theme,
+    required this.useGps,
+    required this.manualLocation,
+    required this.notificationsEnabled,
+  });
+
+  /// Active theme name; one of `'system'`, `'light'`, or `'dark'`.
+  final String theme;
+
+  /// Whether GPS location is enabled. When `false`, [manualLocation] is used.
+  final bool useGps;
+
+  /// Manually entered location string; `null` when not set.
+  final String? manualLocation;
+
+  /// Whether push notifications are enabled.
+  final bool notificationsEnabled;
+}

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -124,9 +124,6 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
 
     if (!ref.mounted) return;
 
-    final SettingsState? current = state.value;
-    if (current == null) return;
-
-    state = AsyncValue<SettingsState>.data(update(current));
+    state = AsyncValue<SettingsState>.data(update(state.requireValue));
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -112,8 +112,6 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
     required Future<void> Function(Preferences) persist,
     required SettingsState Function(SettingsState) update,
   }) async {
-    if (state.value == null) return;
-
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await persist(prefs);
 

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -112,13 +112,15 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
     required Future<void> Function(Preferences) persist,
     required SettingsState Function(SettingsState) update,
   }) async {
-    final SettingsState? current = state.value;
-    if (current == null) return;
+    if (state.value == null) return;
 
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await persist(prefs);
 
     if (!ref.mounted) return;
+
+    final SettingsState? current = state.value;
+    if (current == null) return;
 
     state = AsyncValue<SettingsState>.data(update(current));
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -86,10 +86,16 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   }
 
   /// Sets the active theme.
-  Future<void> setTheme(String theme) => _update(
-    persist: (Preferences prefs) => prefs.setTheme(theme),
-    update: (SettingsState s) => s.copyWith(theme: theme),
-  );
+  Future<void> setTheme(String theme) {
+    assert(
+      theme == 'system' || theme == 'light' || theme == 'dark',
+      "theme must be 'system', 'light', or 'dark'; got '$theme'",
+    );
+    return _update(
+      persist: (Preferences prefs) => prefs.setTheme(theme),
+      update: (SettingsState s) => s.copyWith(theme: theme),
+    );
+  }
 
   /// Sets whether GPS location is enabled.
   Future<void> setUseGps({required bool value}) => _update(

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -86,42 +86,58 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
 
   /// Sets the active theme and persists it to preferences.
   Future<void> setTheme(String theme) async {
+    final SettingsState? current = state.value;
+    if (current == null) return;
+
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await prefs.setTheme(theme);
+
     if (!ref.mounted) return;
-    state = AsyncValue<SettingsState>.data(
-      state.requireValue.copyWith(theme: theme),
-    );
+
+    state = AsyncValue<SettingsState>.data(current.copyWith(theme: theme));
   }
 
   /// Sets whether GPS location is enabled and persists it to preferences.
   Future<void> setUseGps({required bool value}) async {
+    final SettingsState? current = state.value;
+    if (current == null) return;
+
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await prefs.setUseGps(value: value);
+
     if (!ref.mounted) return;
-    state = AsyncValue<SettingsState>.data(
-      state.requireValue.copyWith(useGps: value),
-    );
+
+    state = AsyncValue<SettingsState>.data(current.copyWith(useGps: value));
   }
 
   /// Sets the manual location string and persists it to preferences.
   Future<void> setManualLocation(String location) async {
+    final SettingsState? current = state.value;
+    if (current == null) return;
+
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await prefs.setManualLocation(location);
+
     if (!ref.mounted) return;
+
     state = AsyncValue<SettingsState>.data(
-      state.requireValue.copyWith(manualLocation: location),
+      current.copyWith(manualLocation: location),
     );
   }
 
   /// Sets whether push notifications are enabled and persists it to
   /// preferences.
   Future<void> setNotificationsEnabled({required bool value}) async {
+    final SettingsState? current = state.value;
+    if (current == null) return;
+
     final Preferences prefs = await ref.read(preferencesProvider.future);
     await prefs.setNotificationsEnabled(value: value);
+
     if (!ref.mounted) return;
+    
     state = AsyncValue<SettingsState>.data(
-      state.requireValue.copyWith(notificationsEnabled: value),
+      current.copyWith(notificationsEnabled: value),
     );
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -86,27 +86,27 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
 
   /// Sets the active theme and persists it to preferences.
   Future<void> setTheme(String theme) => _update(
-    persist: (prefs) => prefs.setTheme(theme),
-    update: (s) => s.copyWith(theme: theme),
+    persist: (Preferences prefs) => prefs.setTheme(theme),
+    update: (SettingsState s) => s.copyWith(theme: theme),
   );
 
   /// Sets whether GPS location is enabled and persists it to preferences.
   Future<void> setUseGps({required bool value}) => _update(
-    persist: (prefs) => prefs.setUseGps(value: value),
-    update: (s) => s.copyWith(useGps: value),
+    persist: (Preferences prefs) => prefs.setUseGps(value: value),
+    update: (SettingsState s) => s.copyWith(useGps: value),
   );
 
   /// Sets the manual location string and persists it to preferences.
   Future<void> setManualLocation(String location) => _update(
-    persist: (prefs) => prefs.setManualLocation(location),
-    update: (s) => s.copyWith(manualLocation: location),
+    persist: (Preferences prefs) => prefs.setManualLocation(location),
+    update: (SettingsState s) => s.copyWith(manualLocation: location),
   );
 
   /// Sets whether push notifications are enabled and persists it to
   /// preferences.
   Future<void> setNotificationsEnabled({required bool value}) => _update(
-    persist: (prefs) => prefs.setNotificationsEnabled(value: value),
-    update: (s) => s.copyWith(notificationsEnabled: value),
+    persist: (Preferences prefs) => prefs.setNotificationsEnabled(value: value),
+    update: (SettingsState s) => s.copyWith(notificationsEnabled: value),
   );
 
   Future<void> _update({

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 /// Holds the user-facing settings state.
 class SettingsState {
@@ -55,6 +59,26 @@ settingsProvider =
 class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   @override
   AsyncValue<SettingsState> build() {
+    unawaited(
+      Future<void>.microtask(() async {
+        try {
+          final Preferences prefs = await ref.read(preferencesProvider.future);
+          if (!ref.mounted) return;
+          state = AsyncValue<SettingsState>.data(
+            SettingsState(
+              theme: prefs.theme,
+              useGps: prefs.useGps,
+              manualLocation: prefs.manualLocation,
+              notificationsEnabled: prefs.notificationsEnabled,
+            ),
+          );
+        } on Object catch (e, st) {
+          if (!ref.mounted) return;
+          state = AsyncValue<SettingsState>.error(e, st);
+        }
+      }),
+    );
+
     return const AsyncValue<SettingsState>.loading();
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -85,59 +85,42 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   }
 
   /// Sets the active theme and persists it to preferences.
-  Future<void> setTheme(String theme) async {
-    final SettingsState? current = state.value;
-    if (current == null) return;
-
-    final Preferences prefs = await ref.read(preferencesProvider.future);
-    await prefs.setTheme(theme);
-
-    if (!ref.mounted) return;
-
-    state = AsyncValue<SettingsState>.data(current.copyWith(theme: theme));
-  }
+  Future<void> setTheme(String theme) => _update(
+    persist: (prefs) => prefs.setTheme(theme),
+    update: (s) => s.copyWith(theme: theme),
+  );
 
   /// Sets whether GPS location is enabled and persists it to preferences.
-  Future<void> setUseGps({required bool value}) async {
-    final SettingsState? current = state.value;
-    if (current == null) return;
-
-    final Preferences prefs = await ref.read(preferencesProvider.future);
-    await prefs.setUseGps(value: value);
-
-    if (!ref.mounted) return;
-
-    state = AsyncValue<SettingsState>.data(current.copyWith(useGps: value));
-  }
+  Future<void> setUseGps({required bool value}) => _update(
+    persist: (prefs) => prefs.setUseGps(value: value),
+    update: (s) => s.copyWith(useGps: value),
+  );
 
   /// Sets the manual location string and persists it to preferences.
-  Future<void> setManualLocation(String location) async {
-    final SettingsState? current = state.value;
-    if (current == null) return;
-
-    final Preferences prefs = await ref.read(preferencesProvider.future);
-    await prefs.setManualLocation(location);
-
-    if (!ref.mounted) return;
-
-    state = AsyncValue<SettingsState>.data(
-      current.copyWith(manualLocation: location),
-    );
-  }
+  Future<void> setManualLocation(String location) => _update(
+    persist: (prefs) => prefs.setManualLocation(location),
+    update: (s) => s.copyWith(manualLocation: location),
+  );
 
   /// Sets whether push notifications are enabled and persists it to
   /// preferences.
-  Future<void> setNotificationsEnabled({required bool value}) async {
+  Future<void> setNotificationsEnabled({required bool value}) => _update(
+    persist: (prefs) => prefs.setNotificationsEnabled(value: value),
+    update: (s) => s.copyWith(notificationsEnabled: value),
+  );
+
+  Future<void> _update({
+    required Future<void> Function(Preferences) persist,
+    required SettingsState Function(SettingsState) update,
+  }) async {
     final SettingsState? current = state.value;
     if (current == null) return;
 
     final Preferences prefs = await ref.read(preferencesProvider.future);
-    await prefs.setNotificationsEnabled(value: value);
+    await persist(prefs);
 
     if (!ref.mounted) return;
 
-    state = AsyncValue<SettingsState>.data(
-      current.copyWith(notificationsEnabled: value),
-    );
+    state = AsyncValue<SettingsState>.data(update(current));
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -63,7 +63,9 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
       Future<void>.microtask(() async {
         try {
           final Preferences prefs = await ref.read(preferencesProvider.future);
+          
           if (!ref.mounted) return;
+          
           state = AsyncValue<SettingsState>.data(
             SettingsState(
               theme: prefs.theme,
@@ -74,11 +76,11 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
           );
         } on Object catch (e, st) {
           if (!ref.mounted) return;
+
           state = AsyncValue<SettingsState>.error(e, st);
         }
       }),
     );
-
     return const AsyncValue<SettingsState>.loading();
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -32,14 +32,11 @@ class SettingsState {
     bool? useGps,
     String? manualLocation,
     bool? notificationsEnabled,
-    bool clearManualLocation = false,
   }) {
     return SettingsState(
       theme: theme ?? this.theme,
       useGps: useGps ?? this.useGps,
-      manualLocation: clearManualLocation
-          ? null
-          : (manualLocation ?? this.manualLocation),
+      manualLocation: manualLocation ?? this.manualLocation,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
     );
   }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -84,26 +84,25 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
     return const AsyncValue<SettingsState>.loading();
   }
 
-  /// Sets the active theme and persists it to preferences.
+  /// Sets the active theme.
   Future<void> setTheme(String theme) => _update(
     persist: (Preferences prefs) => prefs.setTheme(theme),
     update: (SettingsState s) => s.copyWith(theme: theme),
   );
 
-  /// Sets whether GPS location is enabled and persists it to preferences.
+  /// Sets whether GPS location is enabled.
   Future<void> setUseGps({required bool value}) => _update(
     persist: (Preferences prefs) => prefs.setUseGps(value: value),
     update: (SettingsState s) => s.copyWith(useGps: value),
   );
 
-  /// Sets the manual location string and persists it to preferences.
+  /// Sets the manual location string.
   Future<void> setManualLocation(String location) => _update(
     persist: (Preferences prefs) => prefs.setManualLocation(location),
     update: (SettingsState s) => s.copyWith(manualLocation: location),
   );
 
-  /// Sets whether push notifications are enabled and persists it to
-  /// preferences.
+  /// Sets whether push notifications are enabled.
   Future<void> setNotificationsEnabled({required bool value}) => _update(
     persist: (Preferences prefs) => prefs.setNotificationsEnabled(value: value),
     update: (SettingsState s) => s.copyWith(notificationsEnabled: value),

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,3 +1,5 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
 /// Holds the user-facing settings state.
 class SettingsState {
   /// Creates a [SettingsState] with all fields required.
@@ -36,5 +38,23 @@ class SettingsState {
           : (manualLocation ?? this.manualLocation),
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
     );
+  }
+}
+
+/// Riverpod provider for [SettingsNotifier].
+final NotifierProvider<SettingsNotifier, AsyncValue<SettingsState>>
+settingsProvider =
+    NotifierProvider<SettingsNotifier, AsyncValue<SettingsState>>(
+      SettingsNotifier.new,
+    );
+
+/// Manages user settings state.
+///
+/// Reads initial values from preferences on first build and persists each
+/// change back immediately.
+class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
+  @override
+  AsyncValue<SettingsState> build() {
+    return const AsyncValue<SettingsState>.loading();
   }
 }

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -63,9 +63,9 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
       Future<void>.microtask(() async {
         try {
           final Preferences prefs = await ref.read(preferencesProvider.future);
-          
+
           if (!ref.mounted) return;
-          
+
           state = AsyncValue<SettingsState>.data(
             SettingsState(
               theme: prefs.theme,

--- a/lib/providers/uv_provider.dart
+++ b/lib/providers/uv_provider.dart
@@ -11,8 +11,9 @@ import 'package:uvalert/storage/cache.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 /// Provides the proxy base URL. Overridable in tests.
-final Provider<String> proxyBaseUrlProvider =
-    Provider<String>((_) => proxyBaseUrl);
+final Provider<String> proxyBaseUrlProvider = Provider<String>(
+  (_) => proxyBaseUrl,
+);
 
 /// Provides a [Cache] backed by [Preferences].
 final FutureProvider<Cache> cacheProvider = FutureProvider<Cache>((

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -73,6 +73,15 @@ void main() {
   // setTheme
   // -------------------------------------------------------------------------
 
+  test('setTheme rejects invalid theme value', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
+
+    expect(
+      () => container.read(settingsProvider.notifier).setTheme('invalid'),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+
   test('setTheme updates theme in state', () async {
     final ProviderContainer container = await _makeLoadedContainer();
 

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -132,4 +132,22 @@ void main() {
       );
     },
   );
+
+  // -------------------------------------------------------------------------
+  // concurrent updates
+  // -------------------------------------------------------------------------
+
+  test('concurrent setTheme and setUseGps both apply', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
+    final SettingsNotifier notifier = container.read(settingsProvider.notifier);
+
+    await Future.wait(<Future<void>>[
+      notifier.setTheme('dark'),
+      notifier.setUseGps(value: false),
+    ]);
+
+    final SettingsState result = container.read(settingsProvider).requireValue;
+    expect(result.theme, 'dark');
+    expect(result.useGps, isFalse);
+  });
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -85,16 +85,13 @@ void main() {
   // setUseGps
   // -------------------------------------------------------------------------
 
-  test(
-    'setUseGps updates useGps in state',
-    () async {
-      final ProviderContainer container = await _makeLoadedContainer();
+  test('setUseGps updates useGps in state', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
 
-      await container.read(settingsProvider.notifier).setUseGps(value: false);
+    await container.read(settingsProvider.notifier).setUseGps(value: false);
 
-      expect(container.read(settingsProvider).requireValue.useGps, isFalse);
-    },
-  );
+    expect(container.read(settingsProvider).requireValue.useGps, isFalse);
+  });
 
   // -------------------------------------------------------------------------
   // setManualLocation

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -120,8 +120,7 @@ void main() {
   // setNotificationsEnabled
   // -------------------------------------------------------------------------
 
-  test('setNotificationsEnabled updates notificationsEnabled in state and'
-      ' persists to preferences', () async {
+  test('setNotificationsEnabled updates notificationsEnabled in state', () async {
     final ProviderContainer container = await _makeLoadedContainer();
 
     await container

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -89,7 +89,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   test(
-    'setUseGps updates useGps in state and persists to preferences',
+    'setUseGps updates useGps in state',
     () async {
       final ProviderContainer container = await _makeLoadedContainer();
 

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/providers/settings_provider.dart';
+
+ProviderContainer _makeContainer() {
+  final ProviderContainer container = ProviderContainer();
+  addTearDown(container.dispose);
+  return container;
+}
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  test('initial state is AsyncLoading', () {
+    final ProviderContainer container = _makeContainer();
+
+    expect(
+      container.read(settingsProvider),
+      isA<AsyncLoading<SettingsState>>(),
+    );
+  });
+}

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -76,7 +76,7 @@ void main() {
   // setTheme
   // -------------------------------------------------------------------------
 
-  test('setTheme updates theme in state and persists to preferences', () async {
+  test('setTheme updates theme in state', () async {
     final ProviderContainer container = await _makeLoadedContainer();
 
     await container.read(settingsProvider.notifier).setTheme('dark');

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -103,8 +103,7 @@ void main() {
   // setManualLocation
   // -------------------------------------------------------------------------
 
-  test('setManualLocation updates manualLocation in state and persists to'
-      ' preferences', () async {
+  test('setManualLocation updates manualLocation in state', () async {
     final ProviderContainer container = await _makeLoadedContainer();
 
     await container

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -40,10 +40,7 @@ void main() {
   // -------------------------------------------------------------------------
 
   test('build() loads default values from preferences', () async {
-    final ProviderContainer container = _makeContainer();
-
-    await (container..read(settingsProvider)).read(preferencesProvider.future);
-    await Future<void>.delayed(Duration.zero);
+    final ProviderContainer container = await _makeLoadedContainer();
 
     final SettingsState settings = container
         .read(settingsProvider)

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -123,15 +123,16 @@ void main() {
   test(
     'setNotificationsEnabled updates notificationsEnabled in state',
     () async {
-    final ProviderContainer container = await _makeLoadedContainer();
+      final ProviderContainer container = await _makeLoadedContainer();
 
-    await container
-        .read(settingsProvider.notifier)
-        .setNotificationsEnabled(value: true);
+      await container
+          .read(settingsProvider.notifier)
+          .setNotificationsEnabled(value: true);
 
-    expect(
-      container.read(settingsProvider).requireValue.notificationsEnabled,
-      isTrue,
-    );
-  });
+      expect(
+        container.read(settingsProvider).requireValue.notificationsEnabled,
+        isTrue,
+      );
+    },
+  );
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -131,36 +131,6 @@ void main() {
   );
 
   // -------------------------------------------------------------------------
-  // _update — null current state guard
-  // -------------------------------------------------------------------------
-
-  test('_update is a no-op when state has no value (AsyncError)', () async {
-    // Put the notifier into AsyncError so state.value is null, then call
-    // setTheme - the null-guard should fire and leave state unchanged.
-    final ProviderContainer container = ProviderContainer(
-      // Type inference on the overrides list is not exposed publicly in
-      // flutter_riverpod.
-      // ignore: always_specify_types
-      overrides: [
-        preferencesProvider.overrideWith(
-          (_) async => throw StateError('prefs unavailable'),
-        ),
-      ],
-    );
-    addTearDown(container.dispose);
-
-    container.read(settingsProvider);
-    await Future<void>.delayed(Duration.zero);
-
-    expect(container.read(settingsProvider), isA<AsyncError<SettingsState>>());
-
-    await container.read(settingsProvider.notifier).setTheme('dark');
-
-    // State should remain AsyncError because the null-guard fired.
-    expect(container.read(settingsProvider), isA<AsyncError<SettingsState>>());
-  });
-
-  // -------------------------------------------------------------------------
   // concurrent updates
   // -------------------------------------------------------------------------
 

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -134,19 +134,30 @@ void main() {
   // _update — null current state guard
   // -------------------------------------------------------------------------
 
-  test('_update is a no-op when state has no value (still loading)', () async {
-    // Call setTheme before the build() microtask resolves so state.value
-    // is null.
-    final ProviderContainer container = _makeContainer()
-      ..read(settingsProvider); // triggers build(), still AsyncLoading
+  test('_update is a no-op when state has no value (AsyncError)', () async {
+    // Put the notifier into AsyncError so state.value is null, then call
+    // setTheme - the null-guard should fire and leave state unchanged.
+    final ProviderContainer container = ProviderContainer(
+      // Type inference on the overrides list is not exposed publicly in
+      // flutter_riverpod.
+      // ignore: always_specify_types
+      overrides: [
+        preferencesProvider.overrideWith(
+          (_) async => throw StateError('prefs unavailable'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(settingsProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(settingsProvider), isA<AsyncError<SettingsState>>());
 
     await container.read(settingsProvider.notifier).setTheme('dark');
 
-    // State should remain AsyncLoading because the null-guard fired first.
-    expect(
-      container.read(settingsProvider),
-      isA<AsyncLoading<SettingsState>>(),
-    );
+    // State should remain AsyncError because the null-guard fired.
+    expect(container.read(settingsProvider), isA<AsyncError<SettingsState>>());
   });
 
   // -------------------------------------------------------------------------

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 
 ProviderContainer _makeContainer() {
@@ -25,5 +26,23 @@ void main() {
       container.read(settingsProvider),
       isA<AsyncLoading<SettingsState>>(),
     );
+  });
+
+  // -------------------------------------------------------------------------
+  // build() — loads from preferences
+  // -------------------------------------------------------------------------
+
+  test('build() loads default values from preferences', () async {
+    final ProviderContainer container = _makeContainer();
+
+    await (container..read(settingsProvider)).read(preferencesProvider.future);
+    await Future<void>.delayed(Duration.zero);
+
+    final SettingsState settings =
+        container.read(settingsProvider).requireValue;
+    expect(settings.theme, 'system');
+    expect(settings.useGps, isTrue);
+    expect(settings.manualLocation, isNull);
+    expect(settings.notificationsEnabled, isFalse);
   });
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -10,6 +10,13 @@ ProviderContainer _makeContainer() {
   return container;
 }
 
+Future<ProviderContainer> _makeLoadedContainer() async {
+  final ProviderContainer container = _makeContainer();
+  await (container..read(settingsProvider)).read(preferencesProvider.future);
+  await Future<void>.delayed(Duration.zero);
+  return container;
+}
+
 void main() {
   setUp(() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
@@ -44,5 +51,30 @@ void main() {
     expect(settings.useGps, isTrue);
     expect(settings.manualLocation, isNull);
     expect(settings.notificationsEnabled, isFalse);
+  });
+
+  // -------------------------------------------------------------------------
+  // setTheme
+  // -------------------------------------------------------------------------
+
+  test('setTheme updates theme in state and persists to preferences', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
+
+    await container.read(settingsProvider.notifier).setTheme('dark');
+
+    expect(container.read(settingsProvider).requireValue.theme, 'dark');
+  });
+
+  // -------------------------------------------------------------------------
+  // setUseGps
+  // -------------------------------------------------------------------------
+
+  test('setUseGps updates useGps in state and persists to preferences',
+      () async {
+    final ProviderContainer container = await _makeLoadedContainer();
+
+    await container.read(settingsProvider.notifier).setUseGps(value: false);
+
+    expect(container.read(settingsProvider).requireValue.useGps, isFalse);
   });
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -45,8 +45,9 @@ void main() {
     await (container..read(settingsProvider)).read(preferencesProvider.future);
     await Future<void>.delayed(Duration.zero);
 
-    final SettingsState settings =
-        container.read(settingsProvider).requireValue;
+    final SettingsState settings = container
+        .read(settingsProvider)
+        .requireValue;
     expect(settings.theme, 'system');
     expect(settings.useGps, isTrue);
     expect(settings.manualLocation, isNull);
@@ -69,54 +70,50 @@ void main() {
   // setUseGps
   // -------------------------------------------------------------------------
 
-  test('setUseGps updates useGps in state and persists to preferences',
-      () async {
-    final ProviderContainer container = await _makeLoadedContainer();
+  test(
+    'setUseGps updates useGps in state and persists to preferences',
+    () async {
+      final ProviderContainer container = await _makeLoadedContainer();
 
-    await container.read(settingsProvider.notifier).setUseGps(value: false);
+      await container.read(settingsProvider.notifier).setUseGps(value: false);
 
-    expect(container.read(settingsProvider).requireValue.useGps, isFalse);
-  });
+      expect(container.read(settingsProvider).requireValue.useGps, isFalse);
+    },
+  );
 
   // -------------------------------------------------------------------------
   // setManualLocation
   // -------------------------------------------------------------------------
 
-  test(
-    'setManualLocation updates manualLocation in state and persists to'
-    ' preferences',
-    () async {
-      final ProviderContainer container = await _makeLoadedContainer();
+  test('setManualLocation updates manualLocation in state and persists to'
+      ' preferences', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
 
-      await container
-          .read(settingsProvider.notifier)
-          .setManualLocation('New York, NY');
+    await container
+        .read(settingsProvider.notifier)
+        .setManualLocation('New York, NY');
 
-      expect(
-        container.read(settingsProvider).requireValue.manualLocation,
-        'New York, NY',
-      );
-    },
-  );
+    expect(
+      container.read(settingsProvider).requireValue.manualLocation,
+      'New York, NY',
+    );
+  });
 
   // -------------------------------------------------------------------------
   // setNotificationsEnabled
   // -------------------------------------------------------------------------
 
-  test(
-    'setNotificationsEnabled updates notificationsEnabled in state and'
-    ' persists to preferences',
-    () async {
-      final ProviderContainer container = await _makeLoadedContainer();
+  test('setNotificationsEnabled updates notificationsEnabled in state and'
+      ' persists to preferences', () async {
+    final ProviderContainer container = await _makeLoadedContainer();
 
-      await container
-          .read(settingsProvider.notifier)
-          .setNotificationsEnabled(value: true);
+    await container
+        .read(settingsProvider.notifier)
+        .setNotificationsEnabled(value: true);
 
-      expect(
-        container.read(settingsProvider).requireValue.notificationsEnabled,
-        isTrue,
-      );
-    },
-  );
+    expect(
+      container.read(settingsProvider).requireValue.notificationsEnabled,
+      isTrue,
+    );
+  });
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -54,6 +54,24 @@ void main() {
     expect(settings.notificationsEnabled, isFalse);
   });
 
+  test('build() sets AsyncError when preferencesProvider throws', () async {
+    final ProviderContainer container = ProviderContainer(
+      // Override type inference is not exposed publicly in flutter_riverpod.
+      // ignore: always_specify_types
+      overrides: [
+        preferencesProvider.overrideWith(
+          (_) async => throw StateError('prefs unavailable'),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    container.read(settingsProvider);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(container.read(settingsProvider), isA<AsyncError<SettingsState>>());
+  });
+
   // -------------------------------------------------------------------------
   // setTheme
   // -------------------------------------------------------------------------

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -77,4 +77,46 @@ void main() {
 
     expect(container.read(settingsProvider).requireValue.useGps, isFalse);
   });
+
+  // -------------------------------------------------------------------------
+  // setManualLocation
+  // -------------------------------------------------------------------------
+
+  test(
+    'setManualLocation updates manualLocation in state and persists to'
+    ' preferences',
+    () async {
+      final ProviderContainer container = await _makeLoadedContainer();
+
+      await container
+          .read(settingsProvider.notifier)
+          .setManualLocation('New York, NY');
+
+      expect(
+        container.read(settingsProvider).requireValue.manualLocation,
+        'New York, NY',
+      );
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // setNotificationsEnabled
+  // -------------------------------------------------------------------------
+
+  test(
+    'setNotificationsEnabled updates notificationsEnabled in state and'
+    ' persists to preferences',
+    () async {
+      final ProviderContainer container = await _makeLoadedContainer();
+
+      await container
+          .read(settingsProvider.notifier)
+          .setNotificationsEnabled(value: true);
+
+      expect(
+        container.read(settingsProvider).requireValue.notificationsEnabled,
+        isTrue,
+      );
+    },
+  );
 }

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -131,6 +131,25 @@ void main() {
   );
 
   // -------------------------------------------------------------------------
+  // _update — null current state guard
+  // -------------------------------------------------------------------------
+
+  test('_update is a no-op when state has no value (still loading)', () async {
+    // Call setTheme before the build() microtask resolves so state.value
+    // is null.
+    final ProviderContainer container = _makeContainer()
+      ..read(settingsProvider); // triggers build(), still AsyncLoading
+
+    await container.read(settingsProvider.notifier).setTheme('dark');
+
+    // State should remain AsyncLoading because the null-guard fired first.
+    expect(
+      container.read(settingsProvider),
+      isA<AsyncLoading<SettingsState>>(),
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // concurrent updates
   // -------------------------------------------------------------------------
 

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -120,7 +120,9 @@ void main() {
   // setNotificationsEnabled
   // -------------------------------------------------------------------------
 
-  test('setNotificationsEnabled updates notificationsEnabled in state', () async {
+  test(
+    'setNotificationsEnabled updates notificationsEnabled in state',
+    () async {
     final ProviderContainer container = await _makeLoadedContainer();
 
     await container

--- a/test/uv_provider_test.dart
+++ b/test/uv_provider_test.dart
@@ -45,8 +45,7 @@ ProviderContainer _makeContainerWith(_MockUvApi api) {
 /// resolved, so microtasks inside build() can reach their `.wait` without
 /// blocking on the first location change.
 Future<ProviderContainer> _makeWarmContainerWith(_MockUvApi api) async {
-  final ProviderContainer container = _makeContainerWith(api)
-    ..read(uvProvider);
+  final ProviderContainer container = _makeContainerWith(api)..read(uvProvider);
   await container.read(deviceIdProvider.future);
   return container;
 }
@@ -170,22 +169,24 @@ void main() {
     expect(cache, isA<Cache>());
   });
 
-  test('uvApiProvider resolves to UvApi when proxyBaseUrl is non-empty',
-      () async {
-    SharedPreferences.setMockInitialValues(<String, Object>{});
+  test(
+    'uvApiProvider resolves to UvApi when proxyBaseUrl is non-empty',
+    () async {
+      SharedPreferences.setMockInitialValues(<String, Object>{});
 
-    final ProviderContainer container = ProviderContainer(
-      // Override type inference is not exposed publicly in flutter_riverpod.
-      // ignore: always_specify_types
-      overrides: [
-        proxyBaseUrlProvider.overrideWithValue('https://proxy.example.com'),
-      ],
-    );
-    addTearDown(container.dispose);
+      final ProviderContainer container = ProviderContainer(
+        // Override type inference is not exposed publicly in flutter_riverpod.
+        // ignore: always_specify_types
+        overrides: [
+          proxyBaseUrlProvider.overrideWithValue('https://proxy.example.com'),
+        ],
+      );
+      addTearDown(container.dispose);
 
-    final UvApi api = await container.read(uvApiProvider.future);
-    expect(api, isA<UvApi>());
-  });
+      final UvApi api = await container.read(uvApiProvider.future);
+      expect(api, isA<UvApi>());
+    },
+  );
 
   // ---------------------------------------------------------------------------
   // uvApiProvider — empty proxyBaseUrl
@@ -287,9 +288,7 @@ void main() {
     expect(result, data);
 
     // The second fetch (lat:10, lon:20) must have produced the final data.
-    verify(
-      () => mockApi.fetch(lat: 10, lon: 20, uuid: 'test-uuid'),
-    ).called(1);
+    verify(() => mockApi.fetch(lat: 10, lon: 20, uuid: 'test-uuid')).called(1);
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #12

## Features

- Added `SettingsState` class with `copyWith` for encapsulating user settings (theme, GPS/manual toggle, notification preferences)
- Implemented `SettingsNotifier` to manage settings state and persist changes back to `Preferences`
- Initialized `SettingsNotifier` with user preferences on `build()`
- Added `settingsProvider` for app-wide access to settings state
- Guarded all state updates against unmounted notifier

## Tests

- Initial state test for `settingsProvider`
- Loading default values from preferences
- `setTheme` and `setUseGps` functionality
- `setManualLocation` functionality
- `AsyncError` handling when `preferencesProvider` fails

## Style

- Formatted files