### PR TITLE
feat: implement first-launch routing in app.dart

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,19 +1,35 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/onboarding_screen.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 /// Root widget of the UV Alert application.
-class UvAlertApp extends StatelessWidget {
-  /// Creates the [UvAlertApp].
+class UvAlertApp extends ConsumerWidget {
+  /// Creates a [UvAlertApp].
   const UvAlertApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<Preferences> prefs = ref.watch(preferencesProvider);
+
     return MaterialApp(
       title: 'UV Alert',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
         useMaterial3: true,
       ),
-      home: const Placeholder(),
+      home: switch (prefs) {
+        AsyncData<Preferences>(:final Preferences value) =>
+          value.isFirstLaunch
+              ? const OnboardingScreen()
+              : const DashboardScreen(),
+        AsyncError<Preferences>() => const Scaffold(
+          body: Center(child: Text('Failed to load preferences.')),
+        ),
+        _ => const Scaffold(body: Center(child: CircularProgressIndicator())),
+      },
     );
   }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,12 @@
+import 'package:flutter/material.dart';
+
+/// The main screen shown after onboarding completes.
+class DashboardScreen extends StatelessWidget {
+  /// Creates a [DashboardScreen].
+  const DashboardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('Dashboard')));
+  }
+}

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/storage/preferences.dart';
+
+/// Shown on first launch only. Marks first launch done then routes to
+/// the dashboard.
+class OnboardingScreen extends ConsumerWidget {
+  /// Creates an [OnboardingScreen].
+  const OnboardingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () async {
+            final Preferences preferences =
+                await ref.read(preferencesProvider.future);
+            await preferences.setFirstLaunchDone();
+            }, child: null,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
@@ -20,10 +22,13 @@ class OnboardingScreen extends ConsumerWidget {
               preferencesProvider.future,
             );
             await preferences.setFirstLaunchDone();
+            ref.invalidate(preferencesProvider);
             if (context.mounted) {
-              await Navigator.of(context).pushReplacement(
-                MaterialPageRoute<void>(
-                  builder: (_) => const DashboardScreen(),
+              unawaited(
+                Navigator.of(context).pushReplacement(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const DashboardScreen(),
+                  ),
                 ),
               );
             }

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 /// Shown on first launch only. Marks first launch done then routes to
@@ -15,10 +16,19 @@ class OnboardingScreen extends ConsumerWidget {
       body: Center(
         child: ElevatedButton(
           onPressed: () async {
-            final Preferences preferences =
-                await ref.read(preferencesProvider.future);
+            final Preferences preferences = await ref.read(
+              preferencesProvider.future,
+            );
             await preferences.setFirstLaunchDone();
-            }, child: null,
+            if (context.mounted) {
+              await Navigator.of(context).pushReplacement(
+                MaterialPageRoute<void>(
+                  builder: (_) => const DashboardScreen(),
+                ),
+              );
+            }
+          },
+          child: const Text('Get Started'),
         ),
       ),
     );

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Typed, prefixed wrapper around [SharedPreferences] for app settings.
@@ -5,6 +6,10 @@ class Preferences {
   Preferences._(this._prefs);
   static const String _prefix = 'uvalert_';
   static const String _keyFirstLaunch = '${_prefix}first_launch';
+
+  /// The SharedPreferences key for [isFirstLaunch]. Exposed for tests only.
+  @visibleForTesting
+  static const String keyFirstLaunchForTesting = _keyFirstLaunch;
   static const String _keyUuid = '${_prefix}uuid';
   static const String _keyTheme = '${_prefix}theme';
   static const String _keyUseGps = '${_prefix}use_gps';

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -6,9 +6,7 @@ void main() {
   testWidgets('DashboardScreen renders Dashboard text', (
     WidgetTester tester,
   ) async {
-    await tester.pumpWidget(
-      const MaterialApp(home: DashboardScreen()),
-    );
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
 
     expect(find.text('Dashboard'), findsOneWidget);
   });

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+
+void main() {
+  testWidgets('DashboardScreen renders Dashboard text', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(home: DashboardScreen()),
+    );
+
+    expect(find.text('Dashboard'), findsOneWidget);
+  });
+}

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/onboarding_screen.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  testWidgets('OnboardingScreen renders Get Started button', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: OnboardingScreen()),
+      ),
+    );
+
+    expect(find.text('Get Started'), findsOneWidget);
+  });
+
+  testWidgets(
+    'tapping Get Started navigates to DashboardScreen',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: OnboardingScreen()),
+        ),
+      );
+
+      await tester.tap(find.text('Get Started'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(DashboardScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping Get Started sets isFirstLaunch to false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(home: OnboardingScreen()),
+        ),
+      );
+
+      await tester.tap(find.text('Get Started'));
+      await tester.pumpAndSettle();
+
+      final SharedPreferences prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('uvalert_first_launch'), isFalse);
+    },
+  );
+}

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -14,44 +14,36 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      const ProviderScope(
-        child: MaterialApp(home: OnboardingScreen()),
-      ),
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
     expect(find.text('Get Started'), findsOneWidget);
   });
 
-  testWidgets(
-    'tapping Get Started navigates to DashboardScreen',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(home: OnboardingScreen()),
-        ),
-      );
+  testWidgets('tapping Get Started navigates to DashboardScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+    );
 
-      await tester.tap(find.text('Get Started'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Get Started'));
+    await tester.pumpAndSettle();
 
-      expect(find.byType(DashboardScreen), findsOneWidget);
-    },
-  );
+    expect(find.byType(DashboardScreen), findsOneWidget);
+  });
 
-  testWidgets(
-    'tapping Get Started sets isFirstLaunch to false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const ProviderScope(
-          child: MaterialApp(home: OnboardingScreen()),
-        ),
-      );
+  testWidgets('tapping Get Started sets isFirstLaunch to false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+    );
 
-      await tester.tap(find.text('Get Started'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Get Started'));
+    await tester.pumpAndSettle();
 
-      final SharedPreferences prefs = await SharedPreferences.getInstance();
-      expect(prefs.getBool('uvalert_first_launch'), isFalse);
-    },
-  );
+    final SharedPreferences prefs = await SharedPreferences.getInstance();
+    expect(prefs.getBool('uvalert_first_launch'), isFalse);
+  });
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 void main() {
   setUp(() {
@@ -43,7 +44,7 @@ void main() {
     await tester.tap(find.text('Get Started'));
     await tester.pumpAndSettle();
 
-    final SharedPreferences prefs = await SharedPreferences.getInstance();
-    expect(prefs.getBool('uvalert_first_launch'), isFalse);
+    final Preferences prefs = await Preferences.load();
+    expect(prefs.isFirstLaunch, isFalse);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -6,6 +6,7 @@ import 'package:uvalert/app.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 void main() {
   testWidgets('UvAlertApp shows OnboardingScreen on first launch', (
@@ -23,7 +24,7 @@ void main() {
     WidgetTester tester,
   ) async {
     SharedPreferences.setMockInitialValues(<String, Object>{
-      'uvalert_first_launch': false,
+      Preferences.keyFirstLaunchForTesting: false,
     });
 
     await tester.pumpWidget(const ProviderScope(child: UvAlertApp()));

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,10 +1,65 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/app.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/onboarding_screen.dart';
 
 void main() {
-  testWidgets('UvAlertApp renders without error', (WidgetTester tester) async {
+  testWidgets('UvAlertApp shows OnboardingScreen on first launch', (
+    WidgetTester tester,
+  ) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+
     await tester.pumpWidget(const ProviderScope(child: UvAlertApp()));
-    expect(find.byType(UvAlertApp), findsOneWidget);
+    await tester.pumpAndSettle();
+
+    expect(find.byType(OnboardingScreen), findsOneWidget);
+  });
+
+  testWidgets('UvAlertApp shows DashboardScreen when not first launch', (
+    WidgetTester tester,
+  ) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'uvalert_first_launch': false,
+    });
+
+    await tester.pumpWidget(const ProviderScope(child: UvAlertApp()));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DashboardScreen), findsOneWidget);
+  });
+
+  testWidgets('UvAlertApp shows loading indicator while preferences load', (
+    WidgetTester tester,
+  ) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+
+    await tester.pumpWidget(const ProviderScope(child: UvAlertApp()));
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('UvAlertApp shows error message when preferences fail', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      ProviderScope(
+        // overrideWith type inference is not exposed publicly
+        // in flutter_riverpod
+        // ignore: always_specify_types
+        overrides: [
+          preferencesProvider.overrideWith(
+            (_) async => throw StateError('prefs unavailable'),
+          ),
+        ],
+        child: const UvAlertApp(),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Failed to load preferences.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
Closes #16

## Features

- Implemented `OnboardingScreen` for first-time users
- Implemented `DashboardScreen` for post-onboarding experience
- Added first-launch routing in `app.dart`: checks `Preferences.isFirstLaunch` on startup, routes to `OnboardingScreen` on first launch and `DashboardScreen` on subsequent launches
- Calls `setFirstLaunchDone()` after onboarding completes to update the preference
- Added `firstLaunchKey` to `Preferences` to support test overrides

## Tests

- Tests for `OnboardingScreen` button rendering and navigation to `DashboardScreen`
- Tests for `UvAlertApp` first-launch routing and preferences loading

## Style

- Formatted files for consistency