### PR TITLE
feat: implement onboarding theme selection screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # UV Alert
 
 A Flutter app that monitors the UV index at your location and alerts you when
-exposure risk is high. Targets Android and Linux desktop.
+exposure risk is high. Targets Android.
 
 ## Features
 
@@ -28,7 +28,7 @@ lib/
   providers/    # Riverpod notifiers and providers: UvNotifier, LocationNotifier,
                 #   SettingsNotifier, deviceIdProvider, preferencesProvider
   storage/      # Cache - 24-hour staleness check; Preferences - SharedPrefs wrapper
-  app.dart      # Root widget and Material 3 theme
+  app.dart      # Root widget; Material 3 theme with light/dark/system ThemeMode
   constants.dart # App-wide constants
   main.dart     # Entry point with Riverpod ProviderScope and zone error hooks
 ```
@@ -57,9 +57,6 @@ flutter pub get
 
 # Run on a connected device or emulator
 flutter run
-
-# Run on Linux desktop
-flutter run -d linux
 ```
 
 ## Running Tests

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
@@ -10,9 +11,23 @@ class UvAlertApp extends ConsumerWidget {
   /// Creates a [UvAlertApp].
   const UvAlertApp({super.key});
 
+  // Converts the stored theme string to a Flutter ThemeMode.
+  // 'light' -> light, 'dark' -> dark, anything else -> system.
+  static ThemeMode _toThemeMode(String theme) => switch (theme) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<Preferences> prefs = ref.watch(preferencesProvider);
+    final AsyncValue<SettingsState> settings = ref.watch(settingsProvider);
+
+    // Fall back to system theme while settings are loading or on error.
+    final ThemeMode themeMode =
+        settings.whenData((SettingsState s) => _toThemeMode(s.theme)).value ??
+        ThemeMode.system;
 
     return MaterialApp(
       title: 'UV Alert',
@@ -20,6 +35,14 @@ class UvAlertApp extends ConsumerWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
         useMaterial3: true,
       ),
+      darkTheme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(
+          seedColor: Colors.orange,
+          brightness: Brightness.dark,
+        ),
+        useMaterial3: true,
+      ),
+      themeMode: themeMode,
       home: switch (prefs) {
         AsyncData<Preferences>(:final Preferences value) =>
           value.isFirstLaunch

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,10 +6,16 @@ import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
-ThemeData _appTheme(Brightness brightness) => ThemeData(
+// Built once at startup; ColorScheme.fromSeed is expensive to repeat each build.
+final ThemeData _lightTheme = ThemeData(
+  colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
+  useMaterial3: true,
+);
+
+final ThemeData _darkTheme = ThemeData(
   colorScheme: ColorScheme.fromSeed(
     seedColor: Colors.orange,
-    brightness: brightness,
+    brightness: Brightness.dark,
   ),
   useMaterial3: true,
 );
@@ -22,17 +28,20 @@ class UvAlertApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<Preferences> prefs = ref.watch(preferencesProvider);
-    final AsyncValue<SettingsState> settings = ref.watch(settingsProvider);
 
     // Fall back to system theme while settings are loading or on error.
-    final ThemeMode themeMode =
-        settings.whenData((SettingsState s) => s.themeMode).value ??
-        ThemeMode.system;
+    final ThemeMode themeMode = ref.watch(
+      settingsProvider.select(
+        (AsyncValue<SettingsState> s) =>
+            s.whenData((SettingsState st) => st.themeMode).value ??
+            ThemeMode.system,
+      ),
+    );
 
     return MaterialApp(
       title: 'UV Alert',
-      theme: _appTheme(Brightness.light),
-      darkTheme: _appTheme(Brightness.dark),
+      theme: _lightTheme,
+      darkTheme: _darkTheme,
       themeMode: themeMode,
       home: switch (prefs) {
         AsyncData<Preferences>(:final Preferences value) =>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,7 +6,7 @@ import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
-// Built once at startup; ColorScheme.fromSeed is expensive to repeat each build.
+// Built once at startup; ColorScheme.fromSeed is expensive per-build.
 final ThemeData _lightTheme = ThemeData(
   colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
   useMaterial3: true,

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -6,6 +6,14 @@ import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
+ThemeData _appTheme(Brightness brightness) => ThemeData(
+  colorScheme: ColorScheme.fromSeed(
+    seedColor: Colors.orange,
+    brightness: brightness,
+  ),
+  useMaterial3: true,
+);
+
 /// Root widget of the UV Alert application.
 class UvAlertApp extends ConsumerWidget {
   /// Creates a [UvAlertApp].
@@ -23,17 +31,8 @@ class UvAlertApp extends ConsumerWidget {
 
     return MaterialApp(
       title: 'UV Alert',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.orange),
-        useMaterial3: true,
-      ),
-      darkTheme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(
-          seedColor: Colors.orange,
-          brightness: Brightness.dark,
-        ),
-        useMaterial3: true,
-      ),
+      theme: _appTheme(Brightness.light),
+      darkTheme: _appTheme(Brightness.dark),
       themeMode: themeMode,
       home: switch (prefs) {
         AsyncData<Preferences>(:final Preferences value) =>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -33,8 +33,7 @@ class UvAlertApp extends ConsumerWidget {
     final ThemeMode themeMode = ref.watch(
       settingsProvider.select(
         (AsyncValue<SettingsState> s) =>
-            s.whenData((SettingsState st) => st.themeMode).value ??
-            ThemeMode.system,
+            s.value?.themeMode ?? ThemeMode.system,
       ),
     );
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -32,8 +32,7 @@ class UvAlertApp extends ConsumerWidget {
     // Fall back to system theme while settings are loading or on error.
     final ThemeMode themeMode = ref.watch(
       settingsProvider.select(
-        (AsyncValue<SettingsState> s) =>
-            s.value?.themeMode ?? ThemeMode.system,
+        (AsyncValue<SettingsState> s) => s.value?.themeMode ?? ThemeMode.system,
       ),
     );
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -11,14 +11,6 @@ class UvAlertApp extends ConsumerWidget {
   /// Creates a [UvAlertApp].
   const UvAlertApp({super.key});
 
-  // Converts the stored theme string to a Flutter ThemeMode.
-  // 'light' -> light, 'dark' -> dark, anything else -> system.
-  static ThemeMode _toThemeMode(String theme) => switch (theme) {
-    'light' => ThemeMode.light,
-    'dark' => ThemeMode.dark,
-    _ => ThemeMode.system,
-  };
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<Preferences> prefs = ref.watch(preferencesProvider);
@@ -26,7 +18,7 @@ class UvAlertApp extends ConsumerWidget {
 
     // Fall back to system theme while settings are loading or on error.
     final ThemeMode themeMode =
-        settings.whenData((SettingsState s) => _toThemeMode(s.theme)).value ??
+        settings.whenData((SettingsState s) => s.themeMode).value ??
         ThemeMode.system;
 
     return MaterialApp(

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -58,6 +58,13 @@ settingsProvider =
 ///
 /// Reads initial values from preferences on first build and persists each
 /// change back immediately.
+///
+/// Uses `Notifier<AsyncValue<SettingsState>>` rather than
+/// `AsyncNotifier<SettingsState>` intentionally. `AsyncNotifier.update()`
+/// puts the provider back into a loading state on every mutation, which
+/// causes UI flicker on each settings change. The manual `AsyncValue`
+/// wrapping here enables optimistic writes: state is updated synchronously
+/// while persistence happens in the background, keeping the UI responsive.
 class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   @override
   AsyncValue<SettingsState> build() {

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -9,21 +9,14 @@ import 'package:uvalert/storage/preferences.dart';
 class SettingsState {
   /// Creates a [SettingsState] with all fields required.
   const SettingsState({
-    required this.theme,
+    required this.themeMode,
     required this.useGps,
     required this.manualLocation,
     required this.notificationsEnabled,
   });
 
-  /// Active theme name; one of `'system'`, `'light'`, or `'dark'`.
-  final String theme;
-
-  /// The Flutter [ThemeMode] corresponding to [theme].
-  ThemeMode get themeMode => switch (theme) {
-    'light' => ThemeMode.light,
-    'dark' => ThemeMode.dark,
-    _ => ThemeMode.system,
-  };
+  /// The active [ThemeMode].
+  final ThemeMode themeMode;
 
   /// Whether GPS location is enabled. When `false`, [manualLocation] is used.
   final bool useGps;
@@ -40,13 +33,13 @@ class SettingsState {
   /// "not set", pass `null` only at construction time -- this method cannot
   /// clear [manualLocation] back to `null` once a value has been stored.
   SettingsState copyWith({
-    String? theme,
+    ThemeMode? themeMode,
     bool? useGps,
     String? manualLocation,
     bool? notificationsEnabled,
   }) {
     return SettingsState(
-      theme: theme ?? this.theme,
+      themeMode: themeMode ?? this.themeMode,
       useGps: useGps ?? this.useGps,
       manualLocation: manualLocation ?? this.manualLocation,
       notificationsEnabled: notificationsEnabled ?? this.notificationsEnabled,
@@ -77,7 +70,7 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
 
           state = AsyncValue<SettingsState>.data(
             SettingsState(
-              theme: prefs.theme,
+              themeMode: prefs.theme,
               useGps: prefs.useGps,
               manualLocation: prefs.manualLocation,
               notificationsEnabled: prefs.notificationsEnabled,
@@ -94,16 +87,10 @@ class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   }
 
   /// Sets the active theme.
-  Future<void> setTheme(String theme) {
-    assert(
-      theme == 'system' || theme == 'light' || theme == 'dark',
-      "theme must be 'system', 'light', or 'dark'; got '$theme'",
-    );
-    return _update(
-      persist: (Preferences prefs) => prefs.setTheme(theme),
-      update: (SettingsState s) => s.copyWith(theme: theme),
-    );
-  }
+  Future<void> setTheme(ThemeMode themeMode) => _update(
+    persist: (Preferences prefs) => prefs.setTheme(themeMode),
+    update: (SettingsState s) => s.copyWith(themeMode: themeMode),
+  );
 
   /// Sets whether GPS location is enabled.
   Future<void> setUseGps({required bool value}) => _update(

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/storage/preferences.dart';
@@ -16,6 +17,13 @@ class SettingsState {
 
   /// Active theme name; one of `'system'`, `'light'`, or `'dark'`.
   final String theme;
+
+  /// The Flutter [ThemeMode] corresponding to [theme].
+  ThemeMode get themeMode => switch (theme) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
 
   /// Whether GPS location is enabled. When `false`, [manualLocation] is used.
   final bool useGps;

--- a/lib/providers/settings_provider.dart
+++ b/lib/providers/settings_provider.dart
@@ -63,8 +63,8 @@ settingsProvider =
 /// `AsyncNotifier<SettingsState>` intentionally. `AsyncNotifier.update()`
 /// puts the provider back into a loading state on every mutation, which
 /// causes UI flicker on each settings change. The manual `AsyncValue`
-/// wrapping here enables optimistic writes: state is updated synchronously
-/// while persistence happens in the background, keeping the UI responsive.
+/// wrapping here lets `_update` persist first, then update state atomically,
+/// avoiding the loading-state flicker without sacrificing write correctness.
 class SettingsNotifier extends Notifier<AsyncValue<SettingsState>> {
   @override
   AsyncValue<SettingsState> build() {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -151,7 +151,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 ),
 
               const Spacer(),
-              const _ProgressDots(
+              const ProgressDots(
                 current: _onboardingThemeScreenIndex,
                 total: _totalOnboardingSteps,
               ),
@@ -245,11 +245,14 @@ class _ThemeCard extends StatelessWidget {
 }
 
 /// Three dots indicating progress through onboarding screens.
-class _ProgressDots extends StatelessWidget {
-  const _ProgressDots({required this.current, required this.total});
+class ProgressDots extends StatelessWidget {
+  /// Creates a [ProgressDots] widget.
+  const ProgressDots({required this.current, required this.total, super.key});
 
-  // Zero-based index of the current screen.
+  /// Zero-based index of the current screen.
   final int current;
+
+  /// Total number of onboarding screens.
   final int total;
 
   @override

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -151,7 +151,7 @@ class _ThemeCard extends StatelessWidget {
   final String label;
   final IconData icon;
   final bool selected;
-  final Future<void> Function() onTap;
+  final VoidCallback onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -98,11 +98,12 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _onContinue() async {
-    await ref.read(settingsProvider.notifier).setTheme(_selectedTheme);
-
     final Preferences prefs = await ref.read(preferencesProvider.future);
 
-    await prefs.setFirstLaunchDone();
+    await Future.wait(<Future<void>>[
+      ref.read(settingsProvider.notifier).setTheme(_selectedTheme),
+      prefs.setFirstLaunchDone(),
+    ]);
 
     ref.invalidate(preferencesProvider);
 
@@ -140,6 +141,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               for (final (String label, IconData icon, ThemeMode mode)
                   in _themeOptions)
                 _ThemeCard(
+                  key: ValueKey<ThemeMode>(mode),
                   label: label,
                   icon: icon,
                   selected: _selectedTheme == mode,
@@ -174,6 +176,7 @@ class _ThemeCard extends StatelessWidget {
     required this.icon,
     required this.selected,
     required this.onTap,
+    super.key,
   });
 
   final String label;
@@ -251,6 +254,8 @@ class _ProgressDots extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
 
+    // TODO(milliorn): animate the active dot transition (AnimatedContainer or
+    // AnimatedSwitcher) once a second onboarding screen exists - issue #13.
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -99,6 +99,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _onContinue() async {
+    // Theme was already persisted by _onSelectTheme on tap; only first-launch
+    // flag needs writing here.
     final Preferences prefs = await ref.read(preferencesProvider.future);
 
     await prefs.setFirstLaunchDone();
@@ -150,7 +152,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 ),
 
               const Spacer(),
-              const ProgressDots(
+              const _ProgressDots(
                 current: _onboardingThemeScreenIndex,
                 total: _totalOnboardingSteps,
               ),
@@ -244,9 +246,9 @@ class _ThemeCard extends StatelessWidget {
 }
 
 /// Three dots indicating progress through onboarding screens.
-class ProgressDots extends StatelessWidget {
-  /// Creates a [ProgressDots] widget.
-  const ProgressDots({required this.current, required this.total, super.key});
+class _ProgressDots extends StatelessWidget {
+  /// Creates a [_ProgressDots] widget.
+  const _ProgressDots({required this.current, required this.total});
 
   /// Zero-based index of the current screen.
   final int current;

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -223,10 +223,7 @@ class _ProgressDots extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(
-      current >= 0 && current < total,
-      'current ($current) must be in [0, $total)',
-    );
+    assert(current >= 0 && current < total, 'current must be in [0, total)');
     final ColorScheme colors = Theme.of(context).colorScheme;
 
     // TODO(milliorn): animate the active dot transition (AnimatedContainer or

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -126,6 +126,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final bool settingsReady = ref.watch(settingsProvider).hasValue;
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -161,7 +163,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  onPressed: _onContinue,
+                  onPressed: settingsReady ? _onContinue : null,
                   child: const Text('Continue'),
                 ),
               ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -88,14 +88,14 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     super.dispose();
   }
 
-  void _onSelectTheme(ThemeMode mode) {
+  Future<void> _onSelectTheme(ThemeMode mode) async {
     // Close the subscription so a late-arriving provider value cannot
     // overwrite the user's explicit choice.
     _settingsSub?.close();
     _settingsSub = null;
     setState(() => _selectedTheme = mode);
     // Apply immediately so the user sees the effect before continuing.
-    unawaited(ref.read(settingsProvider.notifier).setTheme(mode));
+    await ref.read(settingsProvider.notifier).setTheme(mode);
   }
 
   Future<void> _onContinue() async {
@@ -181,7 +181,7 @@ class _ThemeCard extends StatelessWidget {
   final String label;
   final IconData icon;
   final bool selected;
-  final VoidCallback onTap;
+  final Future<void> Function() onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -52,50 +52,14 @@ class OnboardingScreen extends ConsumerStatefulWidget {
   ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
 }
 
-ThemeMode? _themeModeFrom(AsyncValue<SettingsState> s) =>
-    s.value?.themeMode;
-
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
-  // Tracks which theme card is currently selected.
-  late ThemeMode _selectedTheme;
-
-  ProviderSubscription<AsyncValue<SettingsState>>? _settingsSub;
-
-  @override
-  void initState() {
-    super.initState();
-    // Seed from storage so the correct card is pre-selected on re-entry.
-    _selectedTheme =
-        _themeModeFrom(ref.read(settingsProvider)) ?? ThemeMode.system;
-
-    // If settings finish loading after initState, sync the card selection
-    // via setState so Flutter is aware of the state change.
-    _settingsSub = ref.listenManual(settingsProvider, (
-      AsyncValue<SettingsState>? _,
-      AsyncValue<SettingsState> next,
-    ) {
-      final ThemeMode? stored = _themeModeFrom(next);
-
-      if (stored != null && stored != _selectedTheme) {
-        setState(() => _selectedTheme = stored);
-      }
-    });
-  }
-
-  @override
-  void dispose() {
-    _settingsSub?.close();
-    super.dispose();
-  }
+  // Optimistic override: set on tap, cleared once the provider round-trips.
+  ThemeMode? _pendingTheme;
 
   Future<void> _onSelectTheme(ThemeMode mode) async {
-    // Close the subscription so a late-arriving provider value cannot
-    // overwrite the user's explicit choice.
-    _settingsSub?.close();
-    _settingsSub = null;
-    setState(() => _selectedTheme = mode);
-    // Apply immediately so the user sees the effect before continuing.
+    setState(() => _pendingTheme = mode);
     await ref.read(settingsProvider.notifier).setTheme(mode);
+    if (mounted) setState(() => _pendingTheme = null);
   }
 
   Future<void> _onContinue() async {
@@ -120,9 +84,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final bool settingsReady = ref.watch(
-      settingsProvider.select((AsyncValue<SettingsState> s) => s.hasValue),
-    );
+    final AsyncValue<SettingsState> settings = ref.watch(settingsProvider);
+    final bool settingsReady = settings.hasValue;
+    final ThemeMode selectedTheme =
+        _pendingTheme ?? settings.value?.themeMode ?? ThemeMode.system;
 
     return Scaffold(
       body: SafeArea(
@@ -147,7 +112,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                   key: ValueKey<ThemeMode>(mode),
                   label: label,
                   icon: icon,
-                  selected: _selectedTheme == mode,
+                  selected: selectedTheme == mode,
                   onTap: () => _onSelectTheme(mode),
                 ),
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -35,15 +35,12 @@ const double _dotMargin = 4;
 const double _dotSize = 8;
 
 // (label, icon, themeMode) for each selectable theme option.
-const List<(String, IconData, ThemeMode)> _themeOptions = <(
-  String,
-  IconData,
-  ThemeMode,
-)>[
-  ('Light', Icons.light_mode, ThemeMode.light),
-  ('Dark', Icons.dark_mode, ThemeMode.dark),
-  ('System Default', Icons.brightness_auto, ThemeMode.system),
-];
+const List<(String, IconData, ThemeMode)> _themeOptions =
+    <(String, IconData, ThemeMode)>[
+      ('Light', Icons.light_mode, ThemeMode.light),
+      ('Dark', Icons.dark_mode, ThemeMode.dark),
+      ('System Default', Icons.brightness_auto, ThemeMode.system),
+    ];
 
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
@@ -74,6 +71,23 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
             .whenData((SettingsState s) => s.themeMode)
             .value ??
         ThemeMode.system;
+
+    // If settings finish loading after initState, sync the card selection
+    // via setState so Flutter is aware of the state change.
+    ref.listenManual(settingsProvider, (
+      AsyncValue<SettingsState>? _,
+      AsyncValue<SettingsState> next,
+    ) {
+      if (_userHasSelected) return;
+
+      final ThemeMode? stored = next
+          .whenData((SettingsState s) => s.themeMode)
+          .value;
+          
+      if (stored != null && stored != _selectedTheme) {
+        setState(() => _selectedTheme = stored);
+      }
+    });
   }
 
   void _onSelectTheme(ThemeMode mode) {
@@ -104,18 +118,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    // If settings loaded after initState and the user hasn't tapped yet,
-    // sync the selection to whatever is stored.
-    if (!_userHasSelected) {
-      final ThemeMode? stored = ref
-          .watch(settingsProvider)
-          .whenData((SettingsState s) => s.themeMode)
-          .value;
-      if (stored != null && stored != _selectedTheme) {
-        _selectedTheme = stored;
-      }
-    }
-
     return Scaffold(
       body: SafeArea(
         child: Padding(

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -93,19 +93,15 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     // overwrite the user's explicit choice.
     _settingsSub?.close();
     _settingsSub = null;
-    // Theme is applied to settingsProvider (and therefore UvAlertApp) only
-    // when Continue is tapped. Card taps update local selection state only;
-    // no live preview is required and persisting on every tap is unnecessary.
     setState(() => _selectedTheme = mode);
+    // Apply immediately so the user sees the effect before continuing.
+    unawaited(ref.read(settingsProvider.notifier).setTheme(mode));
   }
 
   Future<void> _onContinue() async {
     final Preferences prefs = await ref.read(preferencesProvider.future);
 
-    await Future.wait(<Future<void>>[
-      ref.read(settingsProvider.notifier).setTheme(_selectedTheme),
-      prefs.setFirstLaunchDone(),
-    ]);
+    await prefs.setFirstLaunchDone();
 
     if (!mounted) return;
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -33,12 +33,12 @@ const double _cardIconGap = 16;
 const double _dotMargin = 4;
 const double _dotSize = 8;
 
-// (label, icon, key) for each selectable theme option.
-const List<(String, IconData, String)> _themeOptions =
-    <(String, IconData, String)>[
-      ('Light', Icons.light_mode, 'light'),
-      ('Dark', Icons.dark_mode, 'dark'),
-      ('System Default', Icons.brightness_auto, 'system'),
+// (label, icon, themeMode) for each selectable theme option.
+const List<(String, IconData, ThemeMode)> _themeOptions =
+    <(String, IconData, ThemeMode)>[
+      ('Light', Icons.light_mode, ThemeMode.light),
+      ('Dark', Icons.dark_mode, ThemeMode.dark),
+      ('System Default', Icons.brightness_auto, ThemeMode.system),
     ];
 
 /// Screen 1 of onboarding: lets the user pick a theme.
@@ -54,10 +54,10 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
-  String _selectedTheme = 'system';
+  ThemeMode _selectedTheme = ThemeMode.system;
 
-  void _onSelectTheme(String key) {
-    setState(() => _selectedTheme = key);
+  void _onSelectTheme(ThemeMode mode) {
+    setState(() => _selectedTheme = mode);
   }
 
   Future<void> _onContinue() async {
@@ -99,16 +99,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const SizedBox(height: _headingGap),
 
-              for (final (String label, IconData icon, String key)
+              for (final (String label, IconData icon, ThemeMode mode)
                   in _themeOptions) ...<Widget>[
                 _ThemeCard(
                   label: label,
                   icon: icon,
-                  selected: _selectedTheme == key,
-                  onTap: () => _onSelectTheme(key),
+                  selected: _selectedTheme == mode,
+                  onTap: () => _onSelectTheme(mode),
                 ),
 
-                if ((label, icon, key) != _themeOptions.last)
+                if ((label, icon, mode) != _themeOptions.last)
                   const SizedBox(height: _cardGap),
               ],
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -107,7 +107,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
     ref.invalidate(preferencesProvider);
 
-    // TODO(onboarding): replace with location screen when it exists.
+    // TODO(onboarding): replace with location screen (issue #14).
+    // Full flow: Theme → Location → Notifications → Dashboard.
     unawaited(
       Navigator.of(context).pushReplacement(
         MaterialPageRoute<void>(builder: (_) => const DashboardScreen()),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -98,15 +98,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const SizedBox(height: _headingGap),
 
-              for (final (String label, IconData icon, String key)
-                  in _themeOptions) ...<Widget>[
+              for (int i = 0; i < _themeOptions.length; i++) ...<Widget>[
                 _ThemeCard(
-                  label: label,
-                  icon: icon,
-                  selected: _selectedTheme == key,
-                  onTap: () => _onSelectTheme(key),
+                  label: _themeOptions[i].$1,
+                  icon: _themeOptions[i].$2,
+                  selected: _selectedTheme == _themeOptions[i].$3,
+                  onTap: () => _onSelectTheme(_themeOptions[i].$3),
                 ),
-                if (key != 'system') const SizedBox(height: _cardGap),
+
+                if (i < _themeOptions.length - 1)
+                  const SizedBox(height: _cardGap),
               ],
 
               const Spacer(),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Screen 1 of onboarding: lets the user pick a theme.
-class OnboardingScreen extends StatefulWidget {
+// ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
+// It gives the State class a `ref` to read and write providers.
+
+class OnboardingScreen extends ConsumerStatefulWidget {
   /// Creates an [OnboardingScreen].
   const OnboardingScreen({super.key});
 
   @override
-  State<OnboardingScreen> createState() => _OnboardingScreenState();
+  ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
 }
 
-class _OnboardingScreenState extends State<OnboardingScreen> {
+class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
   String _selectedTheme = 'system';
 
@@ -111,7 +115,7 @@ class _ThemeCard extends StatelessWidget {
             color: selected ? colors.primary : colors.outlineVariant,
             width: selected ? 2 : 1,
           ),
-          
+
           color: selected
               ? colors.primary.withValues(alpha: 0.08)
               : colors.surface,
@@ -120,7 +124,7 @@ class _ThemeCard extends StatelessWidget {
         child: Row(
           children: <Widget>[
             Icon(icon, color: selected ? colors.primary : colors.onSurface),
-            
+
             const SizedBox(width: 16),
 
             Text(

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -255,6 +255,10 @@ class _ProgressDots extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    assert(
+      current >= 0 && current < total,
+      'current ($current) must be in [0, $total)',
+    );
     final ColorScheme colors = Theme.of(context).colorScheme;
 
     // TODO(milliorn): animate the active dot transition (AnimatedContainer or

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -56,14 +56,15 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
   String _selectedTheme = 'system';
 
+  void _onSelectTheme(String key) {
+    setState(() => _selectedTheme = key);
+    unawaited(ref.read(settingsProvider.notifier).setTheme(key));
+  }
+
   Future<void> _onContinue() async {
-    // Fire both persists concurrently -- independent SharedPreferences writes.
     final Preferences prefs = await ref.read(preferencesProvider.future);
 
-    await Future.wait(<Future<void>>[
-      ref.read(settingsProvider.notifier).setTheme(_selectedTheme),
-      prefs.setFirstLaunchDone(),
-    ]);
+    await prefs.setFirstLaunchDone();
 
     ref.invalidate(preferencesProvider);
 
@@ -103,7 +104,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                   label: label,
                   icon: icon,
                   selected: _selectedTheme == key,
-                  onTap: () => setState(() => _selectedTheme = key),
+                  onTap: () => _onSelectTheme(key),
                 ),
                 if (key != 'system') const SizedBox(height: _cardGap),
               ],

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,10 +1,15 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/providers/settings_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
 // It gives the State class a `ref` to read and write providers.
-
 class OnboardingScreen extends ConsumerStatefulWidget {
   /// Creates an [OnboardingScreen].
   const OnboardingScreen({super.key});
@@ -16,6 +21,25 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
   String _selectedTheme = 'system';
+
+  Future<void> _onContinue() async {
+    // Persist the chosen theme via the settings provider.
+    await ref.read(settingsProvider.notifier).setTheme(_selectedTheme);
+
+    // Mark first launch done so this screen never shows again.
+    final Preferences prefs = await ref.read(preferencesProvider.future);
+    await prefs.setFirstLaunchDone();
+    ref.invalidate(preferencesProvider);
+
+    if (!mounted) return;
+
+    // TODO(onboarding): replace with location screen when it exists.
+    unawaited(
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(builder: (_) => const DashboardScreen()),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -69,8 +93,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  // Will persist theme and navigate in Step 3.
-                  onPressed: () {},
+                  onPressed: _onContinue,
                   child: const Text('Continue'),
                 ),
               ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -86,7 +86,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   @override
   Widget build(BuildContext context) {
     final AsyncValue<SettingsState> settings = ref.watch(settingsProvider);
-    final bool settingsReady = settings.hasValue;
+    final bool settingsReady = settings.hasValue || settings.hasError;
     final ThemeMode selectedTheme =
         _pendingTheme ?? settings.value?.themeMode ?? ThemeMode.system;
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -55,6 +55,7 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Optimistic override: set on tap, cleared once the provider round-trips.
   ThemeMode? _pendingTheme;
+  bool _continuing = false;
 
   Future<void> _onSelectTheme(ThemeMode mode) async {
     setState(() => _pendingTheme = mode);
@@ -64,6 +65,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _onContinue() async {
+    if (_continuing) return;
+    
+    setState(() => _continuing = true);
     // Theme was already persisted by _onSelectTheme on tap; only first-launch
     // flag needs writing here.
     final Preferences prefs = await ref.read(preferencesProvider.future);

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -9,12 +9,13 @@ import 'package:uvalert/storage/preferences.dart';
 
 const int _totalOnboardingSteps = 3;
 
+// Zero-based index of this screen in the onboarding flow.
+const int _onboardingThemeScreenIndex = 0;
+
 const double _screenPaddingHorizontal = 24;
 const double _screenPaddingVertical = 32;
 
-const double _headingGap = 32;
 const double _cardGap = 16;
-const double _buttonGap = 24;
 
 const Duration _cardAnimationDuration = Duration(milliseconds: 200);
 
@@ -34,12 +35,15 @@ const double _dotMargin = 4;
 const double _dotSize = 8;
 
 // (label, icon, themeMode) for each selectable theme option.
-const List<(String, IconData, ThemeMode)> _themeOptions =
-    <(String, IconData, ThemeMode)>[
-      ('Light', Icons.light_mode, ThemeMode.light),
-      ('Dark', Icons.dark_mode, ThemeMode.dark),
-      ('System Default', Icons.brightness_auto, ThemeMode.system),
-    ];
+const List<(String, IconData, ThemeMode)> _themeOptions = <(
+  String,
+  IconData,
+  ThemeMode,
+)>[
+  ('Light', Icons.light_mode, ThemeMode.light),
+  ('Dark', Icons.dark_mode, ThemeMode.dark),
+  ('System Default', Icons.brightness_auto, ThemeMode.system),
+];
 
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
@@ -56,6 +60,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
   late ThemeMode _selectedTheme;
 
+  // True once the user has tapped a card; prevents the provider from
+  // overwriting an in-progress choice if settings load arrives late.
+  bool _userHasSelected = false;
+
   @override
   void initState() {
     super.initState();
@@ -69,7 +77,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   void _onSelectTheme(ThemeMode mode) {
-    setState(() => _selectedTheme = mode);
+    setState(() {
+      _selectedTheme = mode;
+      _userHasSelected = true;
+    });
   }
 
   Future<void> _onContinue() async {
@@ -93,6 +104,18 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
+    // If settings loaded after initState and the user hasn't tapped yet,
+    // sync the selection to whatever is stored.
+    if (!_userHasSelected) {
+      final ThemeMode? stored = ref
+          .watch(settingsProvider)
+          .whenData((SettingsState s) => s.themeMode)
+          .value;
+      if (stored != null && stored != _selectedTheme) {
+        _selectedTheme = stored;
+      }
+    }
+
     return Scaffold(
       body: SafeArea(
         child: Padding(
@@ -101,6 +124,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
             vertical: _screenPaddingVertical,
           ),
           child: Column(
+            spacing: _cardGap,
             children: <Widget>[
               const Spacer(),
 
@@ -109,25 +133,20 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
 
-              const SizedBox(height: _headingGap),
-
-              Column(
-                spacing: _cardGap,
-                children: <Widget>[
-                  for (final (String label, IconData icon, ThemeMode mode)
-                      in _themeOptions)
-                    _ThemeCard(
-                      label: label,
-                      icon: icon,
-                      selected: _selectedTheme == mode,
-                      onTap: () => _onSelectTheme(mode),
-                    ),
-                ],
-              ),
+              for (final (String label, IconData icon, ThemeMode mode)
+                  in _themeOptions)
+                _ThemeCard(
+                  label: label,
+                  icon: icon,
+                  selected: _selectedTheme == mode,
+                  onTap: () => _onSelectTheme(mode),
+                ),
 
               const Spacer(),
-              const _ProgressDots(current: 0, total: _totalOnboardingSteps),
-              const SizedBox(height: _buttonGap),
+              const _ProgressDots(
+                current: _onboardingThemeScreenIndex,
+                total: _totalOnboardingSteps,
+              ),
 
               SizedBox(
                 width: double.infinity,

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -1,41 +1,172 @@
-import 'dart:async';
-
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:uvalert/providers/preferences_provider.dart';
-import 'package:uvalert/screens/dashboard_screen.dart';
-import 'package:uvalert/storage/preferences.dart';
 
-/// Shown on first launch only. Marks first launch done then routes to
-/// the dashboard.
-class OnboardingScreen extends ConsumerWidget {
+/// Screen 1 of onboarding: lets the user pick a theme.
+class OnboardingScreen extends StatefulWidget {
   /// Creates an [OnboardingScreen].
   const OnboardingScreen({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  State<OnboardingScreen> createState() => _OnboardingScreenState();
+}
+
+class _OnboardingScreenState extends State<OnboardingScreen> {
+  // Tracks which theme card is currently selected.
+  String _selectedTheme = 'system';
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
-      body: Center(
-        child: ElevatedButton(
-          onPressed: () async {
-            final Preferences preferences = await ref.read(
-              preferencesProvider.future,
-            );
-            await preferences.setFirstLaunchDone();
-            ref.invalidate(preferencesProvider);
-            if (context.mounted) {
-              unawaited(
-                Navigator.of(context).pushReplacement(
-                  MaterialPageRoute<void>(
-                    builder: (_) => const DashboardScreen(),
-                  ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          child: Column(
+            children: <Widget>[
+              const Spacer(),
+
+              Text(
+                'Choose your theme',
+                style: Theme.of(context).textTheme.headlineMedium,
+              ),
+
+              const SizedBox(height: 32),
+
+              _ThemeCard(
+                label: 'Light',
+                icon: Icons.light_mode,
+                value: 'light',
+                selected: _selectedTheme == 'light',
+                onTap: () => setState(() => _selectedTheme = 'light'),
+              ),
+
+              const SizedBox(height: 16),
+
+              _ThemeCard(
+                label: 'Dark',
+                icon: Icons.dark_mode,
+                value: 'dark',
+                selected: _selectedTheme == 'dark',
+                onTap: () => setState(() => _selectedTheme = 'dark'),
+              ),
+
+              const SizedBox(height: 16),
+
+              _ThemeCard(
+                label: 'System Default',
+                icon: Icons.brightness_auto,
+                value: 'system',
+                selected: _selectedTheme == 'system',
+                onTap: () => setState(() => _selectedTheme = 'system'),
+              ),
+
+              const Spacer(),
+              const _ProgressDots(current: 0, total: 3),
+              const SizedBox(height: 24),
+
+              SizedBox(
+                width: double.infinity,
+                child: FilledButton(
+                  // Will persist theme and navigate in Step 3.
+                  onPressed: () {},
+                  child: const Text('Continue'),
                 ),
-              );
-            }
-          },
-          child: const Text('Get Started'),
+              ),
+            ],
+          ),
         ),
       ),
+    );
+  }
+}
+
+/// A single selectable theme card.
+class _ThemeCard extends StatelessWidget {
+  const _ThemeCard({
+    required this.label,
+    required this.icon,
+    required this.value,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final IconData icon;
+  final String value;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+
+    return GestureDetector(
+      onTap: onTap,
+
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+
+          border: Border.all(
+            color: selected ? colors.primary : colors.outlineVariant,
+            width: selected ? 2 : 1,
+          ),
+          
+          color: selected
+              ? colors.primary.withValues(alpha: 0.08)
+              : colors.surface,
+        ),
+
+        child: Row(
+          children: <Widget>[
+            Icon(icon, color: selected ? colors.primary : colors.onSurface),
+            
+            const SizedBox(width: 16),
+
+            Text(
+              label,
+              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                color: selected ? colors.primary : colors.onSurface,
+                fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+              ),
+            ),
+            const Spacer(),
+
+            if (selected) Icon(Icons.check_circle, color: colors.primary),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Three dots indicating progress through onboarding screens.
+class _ProgressDots extends StatelessWidget {
+  const _ProgressDots({required this.current, required this.total});
+
+  // Zero-based index of the current screen.
+  final int current;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color active = Theme.of(context).colorScheme.primary;
+    final Color inactive = Theme.of(context).colorScheme.outlineVariant;
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+
+      children: List<Widget>.generate(total, (int i) {
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: 4),
+          width: 8,
+          height: 8,
+          decoration: BoxDecoration(
+            shape: BoxShape.circle,
+            color: i == current ? active : inactive,
+          ),
+        );
+      }),
     );
   }
 }

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -54,7 +54,18 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
-  ThemeMode _selectedTheme = ThemeMode.system;
+  late ThemeMode _selectedTheme;
+
+  @override
+  void initState() {
+    super.initState();
+    // Seed from storage so the correct card is pre-selected on re-entry.
+    _selectedTheme = ref
+            .read(settingsProvider)
+            .whenData((SettingsState s) => s.themeMode)
+            .value ??
+        ThemeMode.system;
+  }
 
   void _onSelectTheme(ThemeMode mode) {
     setState(() => _selectedTheme = mode);

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -61,7 +61,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               _ThemeCard(
                 label: 'Light',
                 icon: Icons.light_mode,
-                value: 'light',
                 selected: _selectedTheme == 'light',
                 onTap: () => setState(() => _selectedTheme = 'light'),
               ),
@@ -71,7 +70,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               _ThemeCard(
                 label: 'Dark',
                 icon: Icons.dark_mode,
-                value: 'dark',
                 selected: _selectedTheme == 'dark',
                 onTap: () => setState(() => _selectedTheme = 'dark'),
               ),
@@ -81,7 +79,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               _ThemeCard(
                 label: 'System Default',
                 icon: Icons.brightness_auto,
-                value: 'system',
                 selected: _selectedTheme == 'system',
                 onTap: () => setState(() => _selectedTheme = 'system'),
               ),
@@ -110,14 +107,12 @@ class _ThemeCard extends StatelessWidget {
   const _ThemeCard({
     required this.label,
     required this.icon,
-    required this.value,
     required this.selected,
     required this.onTap,
   });
 
   final String label;
   final IconData icon;
-  final String value;
   final bool selected;
   final VoidCallback onTap;
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -65,8 +65,6 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _onContinue() async {
-    if (_continuing) return;
-    
     setState(() => _continuing = true);
     // Theme was already persisted by _onSelectTheme on tap; only first-launch
     // flag needs writing here.
@@ -130,7 +128,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               SizedBox(
                 width: double.infinity,
                 child: FilledButton(
-                  onPressed: settingsReady ? _onContinue : null,
+                  onPressed:
+                      (settingsReady && !_continuing) ? _onContinue : null,
                   child: const Text('Continue'),
                 ),
               ),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -198,8 +198,9 @@ class _ThemeCard extends StatelessWidget {
       button: true,
       selected: selected,
       label: label,
-      child: GestureDetector(
+      child: InkWell(
         onTap: onTap,
+        borderRadius: BorderRadius.circular(_cardBorderRadius),
 
         child: AnimatedContainer(
           duration: _cardAnimationDuration,

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -61,6 +61,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // overwriting an in-progress choice if settings load arrives late.
   bool _userHasSelected = false;
 
+  ProviderSubscription<AsyncValue<SettingsState>>? _settingsSub;
+
   @override
   void initState() {
     super.initState();
@@ -74,7 +76,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
     // If settings finish loading after initState, sync the card selection
     // via setState so Flutter is aware of the state change.
-    ref.listenManual(settingsProvider, (
+    _settingsSub = ref.listenManual(settingsProvider, (
       AsyncValue<SettingsState>? _,
       AsyncValue<SettingsState> next,
     ) {
@@ -88,6 +90,12 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
         setState(() => _selectedTheme = stored);
       }
     });
+  }
+
+  @override
+  void dispose() {
+    _settingsSub?.close();
+    super.dispose();
   }
 
   void _onSelectTheme(ThemeMode mode) {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -83,7 +83,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       final ThemeMode? stored = next
           .whenData((SettingsState s) => s.themeMode)
           .value;
-          
+
       if (stored != null && stored != _selectedTheme) {
         setState(() => _selectedTheme = stored);
       }

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -60,7 +60,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   void initState() {
     super.initState();
     // Seed from storage so the correct card is pre-selected on re-entry.
-    _selectedTheme = ref
+    _selectedTheme =
+        ref
             .read(settingsProvider)
             .whenData((SettingsState s) => s.themeMode)
             .value ??
@@ -160,8 +161,7 @@ class _ThemeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
-    final Color contentColor =
-        selected ? colors.primary : colors.onSurface;
+    final Color contentColor = selected ? colors.primary : colors.onSurface;
 
     return Semantics(
       button: true,
@@ -171,43 +171,43 @@ class _ThemeCard extends StatelessWidget {
         onTap: onTap,
 
         child: AnimatedContainer(
-        duration: _cardAnimationDuration,
-        padding: const EdgeInsets.symmetric(
-          horizontal: _cardPaddingHorizontal,
-          vertical: _cardPaddingVertical,
-        ),
-
-        decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(_cardBorderRadius),
-
-          border: Border.all(
-            color: selected ? colors.primary : colors.outlineVariant,
-            width: selected ? _selectedBorderWidth : _unselectedBorderWidth,
+          duration: _cardAnimationDuration,
+          padding: const EdgeInsets.symmetric(
+            horizontal: _cardPaddingHorizontal,
+            vertical: _cardPaddingVertical,
           ),
 
-          color: selected
-              ? colors.primary.withValues(alpha: _selectedCardOpacity)
-              : colors.surface,
-        ),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(_cardBorderRadius),
 
-        child: Row(
-          children: <Widget>[
-            Icon(icon, color: contentColor),
-
-            const SizedBox(width: _cardIconGap),
-
-            Text(
-              label,
-              style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: contentColor,
-                fontWeight: selected ? FontWeight.bold : FontWeight.normal,
-              ),
+            border: Border.all(
+              color: selected ? colors.primary : colors.outlineVariant,
+              width: selected ? _selectedBorderWidth : _unselectedBorderWidth,
             ),
-            const Spacer(),
 
-            if (selected) Icon(Icons.check_circle, color: colors.primary),
-          ],
-        ),
+            color: selected
+                ? colors.primary.withValues(alpha: _selectedCardOpacity)
+                : colors.surface,
+          ),
+
+          child: Row(
+            children: <Widget>[
+              Icon(icon, color: contentColor),
+
+              const SizedBox(width: _cardIconGap),
+
+              Text(
+                label,
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: contentColor,
+                  fontWeight: selected ? FontWeight.bold : FontWeight.normal,
+                ),
+              ),
+              const Spacer(),
+
+              if (selected) Icon(Icons.check_circle, color: colors.primary),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -36,10 +36,10 @@ const double _dotSize = 8;
 // (label, icon, key) for each selectable theme option.
 const List<(String, IconData, String)> _themeOptions =
     <(String, IconData, String)>[
-  ('Light', Icons.light_mode, 'light'),
-  ('Dark', Icons.dark_mode, 'dark'),
-  ('System Default', Icons.brightness_auto, 'system'),
-];
+      ('Light', Icons.light_mode, 'light'),
+      ('Dark', Icons.dark_mode, 'dark'),
+      ('System Default', Icons.brightness_auto, 'system'),
+    ];
 
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
@@ -155,7 +155,7 @@ class _ThemeCard extends StatelessWidget {
           horizontal: _cardPaddingHorizontal,
           vertical: _cardPaddingVertical,
         ),
-        
+
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(_cardBorderRadius),
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -110,18 +110,19 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const SizedBox(height: _headingGap),
 
-              for (final (String label, IconData icon, ThemeMode mode)
-                  in _themeOptions) ...<Widget>[
-                _ThemeCard(
-                  label: label,
-                  icon: icon,
-                  selected: _selectedTheme == mode,
-                  onTap: () => _onSelectTheme(mode),
-                ),
-
-                if ((label, icon, mode) != _themeOptions.last)
-                  const SizedBox(height: _cardGap),
-              ],
+              Column(
+                spacing: _cardGap,
+                children: <Widget>[
+                  for (final (String label, IconData icon, ThemeMode mode)
+                      in _themeOptions)
+                    _ThemeCard(
+                      label: label,
+                      icon: icon,
+                      selected: _selectedTheme == mode,
+                      onTap: () => _onSelectTheme(mode),
+                    ),
+                ],
+              ),
 
               const Spacer(),
               const _ProgressDots(current: 0, total: _totalOnboardingSteps),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -53,7 +53,7 @@ class OnboardingScreen extends ConsumerStatefulWidget {
 }
 
 ThemeMode? _themeModeFrom(AsyncValue<SettingsState> s) =>
-    s.whenData((SettingsState st) => st.themeMode).value;
+    s.value?.themeMode;
 
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
@@ -103,9 +103,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
     await prefs.setFirstLaunchDone();
 
-    if (!mounted) return;
-
     ref.invalidate(preferencesProvider);
+
+    if (!mounted) return;
 
     // TODO(onboarding): replace with location screen (issue #14).
     // Full flow: Theme → Location → Notifications → Dashboard.
@@ -118,7 +118,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   @override
   Widget build(BuildContext context) {
-    final bool settingsReady = ref.watch(settingsProvider).hasValue;
+    final bool settingsReady = ref.watch(
+      settingsProvider.select((AsyncValue<SettingsState> s) => s.hasValue),
+    );
 
     return Scaffold(
       body: SafeArea(

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -9,7 +9,6 @@ import 'package:uvalert/storage/preferences.dart';
 
 const int _totalOnboardingSteps = 3;
 
-// Zero-based index of this screen in the onboarding flow.
 const int _onboardingThemeScreenIndex = 0;
 
 const double _screenPaddingHorizontal = 24;

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -227,7 +227,7 @@ class _ProgressDots extends StatelessWidget {
     final ColorScheme colors = Theme.of(context).colorScheme;
 
     // TODO(milliorn): animate the active dot transition (AnimatedContainer or
-    // AnimatedSwitcher) once a second onboarding screen exists - issue #13.
+    // AnimatedSwitcher) once a second onboarding screen exists - issue #14.
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -59,7 +59,8 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   Future<void> _onSelectTheme(ThemeMode mode) async {
     setState(() => _pendingTheme = mode);
     await ref.read(settingsProvider.notifier).setTheme(mode);
-    if (mounted) setState(() => _pendingTheme = null);
+    // Only clear the optimistic override if no newer tap has superseded it.
+    if (mounted && _pendingTheme == mode) setState(() => _pendingTheme = null);
   }
 
   Future<void> _onContinue() async {

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -94,6 +94,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     // overwrite the user's explicit choice.
     _settingsSub?.close();
     _settingsSub = null;
+    // Theme is applied to settingsProvider (and therefore UvAlertApp) only
+    // when Continue is tapped. Card taps update local selection state only;
+    // no live preview is required and persisting on every tap is unnecessary.
     setState(() => _selectedTheme = mode);
   }
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -70,9 +70,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
     await prefs.setFirstLaunchDone();
 
-    ref.invalidate(preferencesProvider);
-
     if (!mounted) return;
+
+    ref.invalidate(preferencesProvider);
 
     // TODO(onboarding): replace with location screen (issue #14).
     // Full flow: Theme → Location → Notifications → Dashboard.

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -7,6 +7,8 @@ import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
+const int _totalOnboardingSteps = 3;
+
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
 // It gives the State class a `ref` to read and write providers.
@@ -84,7 +86,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
               ),
 
               const Spacer(),
-              const _ProgressDots(current: 0, total: 3),
+              const _ProgressDots(current: 0, total: _totalOnboardingSteps),
               const SizedBox(height: 24),
 
               SizedBox(

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -33,6 +33,14 @@ const double _cardIconGap = 16;
 const double _dotMargin = 4;
 const double _dotSize = 8;
 
+// (label, icon, key) for each selectable theme option.
+const List<(String, IconData, String)> _themeOptions =
+    <(String, IconData, String)>[
+  ('Light', Icons.light_mode, 'light'),
+  ('Dark', Icons.dark_mode, 'dark'),
+  ('System Default', Icons.brightness_auto, 'system'),
+];
+
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
 // It gives the State class a `ref` to read and write providers.
@@ -49,12 +57,14 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   String _selectedTheme = 'system';
 
   Future<void> _onContinue() async {
-    // Persist the chosen theme via the settings provider.
-    await ref.read(settingsProvider.notifier).setTheme(_selectedTheme);
-
-    // Mark first launch done so this screen never shows again.
+    // Fire both persists concurrently -- independent SharedPreferences writes.
     final Preferences prefs = await ref.read(preferencesProvider.future);
-    await prefs.setFirstLaunchDone();
+
+    await Future.wait(<Future<void>>[
+      ref.read(settingsProvider.notifier).setTheme(_selectedTheme),
+      prefs.setFirstLaunchDone(),
+    ]);
+
     ref.invalidate(preferencesProvider);
 
     if (!mounted) return;
@@ -87,30 +97,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const SizedBox(height: _headingGap),
 
-              _ThemeCard(
-                label: 'Light',
-                icon: Icons.light_mode,
-                selected: _selectedTheme == 'light',
-                onTap: () => setState(() => _selectedTheme = 'light'),
-              ),
-
-              const SizedBox(height: _cardGap),
-
-              _ThemeCard(
-                label: 'Dark',
-                icon: Icons.dark_mode,
-                selected: _selectedTheme == 'dark',
-                onTap: () => setState(() => _selectedTheme = 'dark'),
-              ),
-
-              const SizedBox(height: _cardGap),
-
-              _ThemeCard(
-                label: 'System Default',
-                icon: Icons.brightness_auto,
-                selected: _selectedTheme == 'system',
-                onTap: () => setState(() => _selectedTheme = 'system'),
-              ),
+              for (final (String label, IconData icon, String key)
+                  in _themeOptions) ...<Widget>[
+                _ThemeCard(
+                  label: label,
+                  icon: icon,
+                  selected: _selectedTheme == key,
+                  onTap: () => setState(() => _selectedTheme = key),
+                ),
+                if (key != 'system') const SizedBox(height: _cardGap),
+              ],
 
               const Spacer(),
               const _ProgressDots(current: 0, total: _totalOnboardingSteps),
@@ -158,6 +154,7 @@ class _ThemeCard extends StatelessWidget {
           horizontal: _cardPaddingHorizontal,
           vertical: _cardPaddingVertical,
         ),
+        
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(_cardBorderRadius),
 
@@ -204,8 +201,7 @@ class _ProgressDots extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final Color active = Theme.of(context).colorScheme.primary;
-    final Color inactive = Theme.of(context).colorScheme.outlineVariant;
+    final ColorScheme colors = Theme.of(context).colorScheme;
 
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
@@ -217,7 +213,7 @@ class _ProgressDots extends StatelessWidget {
           height: _dotSize,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: i == current ? active : inactive,
+            color: i == current ? colors.primary : colors.outlineVariant,
           ),
         );
       }),

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -108,9 +108,9 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       prefs.setFirstLaunchDone(),
     ]);
 
-    ref.invalidate(preferencesProvider);
-
     if (!mounted) return;
+
+    ref.invalidate(preferencesProvider);
 
     // TODO(onboarding): replace with location screen when it exists.
     unawaited(

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -53,13 +53,12 @@ class OnboardingScreen extends ConsumerStatefulWidget {
   ConsumerState<OnboardingScreen> createState() => _OnboardingScreenState();
 }
 
+ThemeMode? _themeModeFrom(AsyncValue<SettingsState> s) =>
+    s.whenData((SettingsState st) => st.themeMode).value;
+
 class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   // Tracks which theme card is currently selected.
   late ThemeMode _selectedTheme;
-
-  // True once the user has tapped a card; prevents the provider from
-  // overwriting an in-progress choice if settings load arrives late.
-  bool _userHasSelected = false;
 
   ProviderSubscription<AsyncValue<SettingsState>>? _settingsSub;
 
@@ -68,11 +67,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     super.initState();
     // Seed from storage so the correct card is pre-selected on re-entry.
     _selectedTheme =
-        ref
-            .read(settingsProvider)
-            .whenData((SettingsState s) => s.themeMode)
-            .value ??
-        ThemeMode.system;
+        _themeModeFrom(ref.read(settingsProvider)) ?? ThemeMode.system;
 
     // If settings finish loading after initState, sync the card selection
     // via setState so Flutter is aware of the state change.
@@ -80,11 +75,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
       AsyncValue<SettingsState>? _,
       AsyncValue<SettingsState> next,
     ) {
-      if (_userHasSelected) return;
-
-      final ThemeMode? stored = next
-          .whenData((SettingsState s) => s.themeMode)
-          .value;
+      final ThemeMode? stored = _themeModeFrom(next);
 
       if (stored != null && stored != _selectedTheme) {
         setState(() => _selectedTheme = stored);
@@ -99,10 +90,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   void _onSelectTheme(ThemeMode mode) {
-    setState(() {
-      _selectedTheme = mode;
-      _userHasSelected = true;
-    });
+    // Close the subscription so a late-arriving provider value cannot
+    // overwrite the user's explicit choice.
+    _settingsSub?.close();
+    _settingsSub = null;
+    setState(() => _selectedTheme = mode);
   }
 
   Future<void> _onContinue() async {
@@ -193,6 +185,7 @@ class _ThemeCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
     final Color contentColor = selected ? colors.primary : colors.onSurface;
+    final BorderRadius cardRadius = BorderRadius.circular(_cardBorderRadius);
 
     return Semantics(
       button: true,
@@ -200,7 +193,7 @@ class _ThemeCard extends StatelessWidget {
       label: label,
       child: InkWell(
         onTap: onTap,
-        borderRadius: BorderRadius.circular(_cardBorderRadius),
+        borderRadius: cardRadius,
 
         child: AnimatedContainer(
           duration: _cardAnimationDuration,
@@ -210,7 +203,7 @@ class _ThemeCard extends StatelessWidget {
           ),
 
           decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(_cardBorderRadius),
+            borderRadius: cardRadius,
 
             border: Border.all(
               color: selected ? colors.primary : colors.outlineVariant,

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -162,10 +162,14 @@ class _ThemeCard extends StatelessWidget {
     final Color contentColor =
         selected ? colors.primary : colors.onSurface;
 
-    return GestureDetector(
-      onTap: onTap,
+    return Semantics(
+      button: true,
+      selected: selected,
+      label: label,
+      child: GestureDetector(
+        onTap: onTap,
 
-      child: AnimatedContainer(
+        child: AnimatedContainer(
         duration: _cardAnimationDuration,
         padding: const EdgeInsets.symmetric(
           horizontal: _cardPaddingHorizontal,
@@ -202,6 +206,7 @@ class _ThemeCard extends StatelessWidget {
 
             if (selected) Icon(Icons.check_circle, color: colors.primary),
           ],
+        ),
         ),
       ),
     );

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -9,6 +9,30 @@ import 'package:uvalert/storage/preferences.dart';
 
 const int _totalOnboardingSteps = 3;
 
+const double _screenPaddingHorizontal = 24;
+const double _screenPaddingVertical = 32;
+
+const double _headingGap = 32;
+const double _cardGap = 16;
+const double _buttonGap = 24;
+
+const Duration _cardAnimationDuration = Duration(milliseconds: 200);
+
+const double _cardPaddingHorizontal = 20;
+const double _cardPaddingVertical = 16;
+
+const double _cardBorderRadius = 12;
+
+const double _selectedBorderWidth = 2;
+const double _unselectedBorderWidth = 1;
+
+const double _selectedCardOpacity = 0.08;
+
+const double _cardIconGap = 16;
+
+const double _dotMargin = 4;
+const double _dotSize = 8;
+
 /// Screen 1 of onboarding: lets the user pick a theme.
 // ConsumerStatefulWidget is the Riverpod version of StatefulWidget.
 // It gives the State class a `ref` to read and write providers.
@@ -48,7 +72,10 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
     return Scaffold(
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 32),
+          padding: const EdgeInsets.symmetric(
+            horizontal: _screenPaddingHorizontal,
+            vertical: _screenPaddingVertical,
+          ),
           child: Column(
             children: <Widget>[
               const Spacer(),
@@ -58,7 +85,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 style: Theme.of(context).textTheme.headlineMedium,
               ),
 
-              const SizedBox(height: 32),
+              const SizedBox(height: _headingGap),
 
               _ThemeCard(
                 label: 'Light',
@@ -67,7 +94,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 onTap: () => setState(() => _selectedTheme = 'light'),
               ),
 
-              const SizedBox(height: 16),
+              const SizedBox(height: _cardGap),
 
               _ThemeCard(
                 label: 'Dark',
@@ -76,7 +103,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                 onTap: () => setState(() => _selectedTheme = 'dark'),
               ),
 
-              const SizedBox(height: 16),
+              const SizedBox(height: _cardGap),
 
               _ThemeCard(
                 label: 'System Default',
@@ -87,7 +114,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const Spacer(),
               const _ProgressDots(current: 0, total: _totalOnboardingSteps),
-              const SizedBox(height: 24),
+              const SizedBox(height: _buttonGap),
 
               SizedBox(
                 width: double.infinity,
@@ -126,18 +153,21 @@ class _ThemeCard extends StatelessWidget {
       onTap: onTap,
 
       child: AnimatedContainer(
-        duration: const Duration(milliseconds: 200),
-        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+        duration: _cardAnimationDuration,
+        padding: const EdgeInsets.symmetric(
+          horizontal: _cardPaddingHorizontal,
+          vertical: _cardPaddingVertical,
+        ),
         decoration: BoxDecoration(
-          borderRadius: BorderRadius.circular(12),
+          borderRadius: BorderRadius.circular(_cardBorderRadius),
 
           border: Border.all(
             color: selected ? colors.primary : colors.outlineVariant,
-            width: selected ? 2 : 1,
+            width: selected ? _selectedBorderWidth : _unselectedBorderWidth,
           ),
 
           color: selected
-              ? colors.primary.withValues(alpha: 0.08)
+              ? colors.primary.withValues(alpha: _selectedCardOpacity)
               : colors.surface,
         ),
 
@@ -145,7 +175,7 @@ class _ThemeCard extends StatelessWidget {
           children: <Widget>[
             Icon(icon, color: selected ? colors.primary : colors.onSurface),
 
-            const SizedBox(width: 16),
+            const SizedBox(width: _cardIconGap),
 
             Text(
               label,
@@ -182,9 +212,9 @@ class _ProgressDots extends StatelessWidget {
 
       children: List<Widget>.generate(total, (int i) {
         return Container(
-          margin: const EdgeInsets.symmetric(horizontal: 4),
-          width: 8,
-          height: 8,
+          margin: const EdgeInsets.symmetric(horizontal: _dotMargin),
+          width: _dotSize,
+          height: _dotSize,
           decoration: BoxDecoration(
             shape: BoxShape.circle,
             color: i == current ? active : inactive,

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -72,7 +72,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
   }
 
   Future<void> _onContinue() async {
-    unawaited(ref.read(settingsProvider.notifier).setTheme(_selectedTheme));
+    await ref.read(settingsProvider.notifier).setTheme(_selectedTheme);
 
     final Preferences prefs = await ref.read(preferencesProvider.future);
 

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -58,10 +58,11 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
   void _onSelectTheme(String key) {
     setState(() => _selectedTheme = key);
-    unawaited(ref.read(settingsProvider.notifier).setTheme(key));
   }
 
   Future<void> _onContinue() async {
+    unawaited(ref.read(settingsProvider.notifier).setTheme(_selectedTheme));
+
     final Preferences prefs = await ref.read(preferencesProvider.future);
 
     await prefs.setFirstLaunchDone();
@@ -98,15 +99,16 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
 
               const SizedBox(height: _headingGap),
 
-              for (int i = 0; i < _themeOptions.length; i++) ...<Widget>[
+              for (final (String label, IconData icon, String key)
+                  in _themeOptions) ...<Widget>[
                 _ThemeCard(
-                  label: _themeOptions[i].$1,
-                  icon: _themeOptions[i].$2,
-                  selected: _selectedTheme == _themeOptions[i].$3,
-                  onTap: () => _onSelectTheme(_themeOptions[i].$3),
+                  label: label,
+                  icon: icon,
+                  selected: _selectedTheme == key,
+                  onTap: () => _onSelectTheme(key),
                 ),
 
-                if (i < _themeOptions.length - 1)
+                if ((label, icon, key) != _themeOptions.last)
                   const SizedBox(height: _cardGap),
               ],
 
@@ -146,6 +148,8 @@ class _ThemeCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ColorScheme colors = Theme.of(context).colorScheme;
+    final Color contentColor =
+        selected ? colors.primary : colors.onSurface;
 
     return GestureDetector(
       onTap: onTap,
@@ -172,14 +176,14 @@ class _ThemeCard extends StatelessWidget {
 
         child: Row(
           children: <Widget>[
-            Icon(icon, color: selected ? colors.primary : colors.onSurface),
+            Icon(icon, color: contentColor),
 
             const SizedBox(width: _cardIconGap),
 
             Text(
               label,
               style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                color: selected ? colors.primary : colors.onSurface,
+                color: contentColor,
                 fontWeight: selected ? FontWeight.bold : FontWeight.normal,
               ),
             ),

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -45,7 +45,7 @@ class Preferences {
     final String? stored = _prefs.getString(_keyTheme);
 
     if (stored == null) return ThemeMode.system;
-    
+
     return ThemeMode.values.byName(stored);
   }
 

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+// Computed once; ThemeMode.values never changes at runtime.
+final Map<String, ThemeMode> _themeModeByName = ThemeMode.values.asNameMap();
+
 /// Typed, prefixed wrapper around [SharedPreferences] for app settings.
 class Preferences {
   Preferences._(this._prefs);
@@ -46,7 +49,7 @@ class Preferences {
 
     if (stored == null) return ThemeMode.system;
 
-    return ThemeMode.values.asNameMap()[stored] ?? ThemeMode.system;
+    return _themeModeByName[stored] ?? ThemeMode.system;
   }
 
   /// Stores the active [theme].

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -41,19 +41,17 @@ class Preferences {
   Future<void> setUuid(String uuid) async => _prefs.setString(_keyUuid, uuid);
 
   /// The active [ThemeMode]; defaults to [ThemeMode.system].
-  ThemeMode get theme => switch (_prefs.getString(_keyTheme)) {
-    'light' => ThemeMode.light,
-    'dark' => ThemeMode.dark,
-    _ => ThemeMode.system,
-  };
+  ThemeMode get theme {
+    final String? stored = _prefs.getString(_keyTheme);
+
+    if (stored == null) return ThemeMode.system;
+    
+    return ThemeMode.values.byName(stored);
+  }
 
   /// Stores the active [theme].
   Future<void> setTheme(ThemeMode theme) async =>
-      _prefs.setString(_keyTheme, switch (theme) {
-        ThemeMode.light => 'light',
-        ThemeMode.dark => 'dark',
-        ThemeMode.system => 'system',
-      });
+      _prefs.setString(_keyTheme, theme.name);
 
   /// Whether GPS location is enabled; defaults to `true`.
   bool get useGps => _prefs.getBool(_keyUseGps) ?? true;

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Typed, prefixed wrapper around [SharedPreferences] for app settings.
@@ -40,12 +40,20 @@ class Preferences {
   /// Stores the device [uuid].
   Future<void> setUuid(String uuid) async => _prefs.setString(_keyUuid, uuid);
 
-  /// The active theme name; defaults to `'system'`.
-  String get theme => _prefs.getString(_keyTheme) ?? 'system';
+  /// The active [ThemeMode]; defaults to [ThemeMode.system].
+  ThemeMode get theme => switch (_prefs.getString(_keyTheme)) {
+    'light' => ThemeMode.light,
+    'dark' => ThemeMode.dark,
+    _ => ThemeMode.system,
+  };
 
-  /// Stores the active [theme] name.
-  Future<void> setTheme(String theme) async =>
-      _prefs.setString(_keyTheme, theme);
+  /// Stores the active [theme].
+  Future<void> setTheme(ThemeMode theme) async =>
+      _prefs.setString(_keyTheme, switch (theme) {
+        ThemeMode.light => 'light',
+        ThemeMode.dark => 'dark',
+        ThemeMode.system => 'system',
+      });
 
   /// Whether GPS location is enabled; defaults to `true`.
   bool get useGps => _prefs.getBool(_keyUseGps) ?? true;

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -46,7 +46,7 @@ class Preferences {
 
     if (stored == null) return ThemeMode.system;
 
-    return ThemeMode.values.byName(stored);
+    return ThemeMode.values.asNameMap()[stored] ?? ThemeMode.system;
   }
 
   /// Stores the active [theme].

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -60,9 +60,19 @@ void main() {
     await tester.tap(find.text('Dark'));
     await tester.pump();
 
-    // After tapping Dark, check_circle moves to the Dark card.
-    // We verify there is still exactly one check_circle (no double-selection).
-    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    // After tapping Dark, check_circle must be inside the Dark card's Row,
+    // not just anywhere on screen (which would pass even if the tap did nothing).
+    final Finder darkCardRow = find.ancestor(
+      of: find.text('Dark'),
+      matching: find.byType(Row),
+    );
+    expect(
+      find.descendant(
+        of: darkCardRow,
+        matching: find.byIcon(Icons.check_circle),
+      ),
+      findsOneWidget,
+    );
   });
 
   testWidgets('tapping Continue navigates to DashboardScreen', (

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -11,37 +11,66 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
-  testWidgets('OnboardingScreen renders Get Started button', (
+  testWidgets('OnboardingScreen renders all three theme cards', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
-    expect(find.text('Get Started'), findsOneWidget);
+    expect(find.text('Light'), findsOneWidget);
+    expect(find.text('Dark'), findsOneWidget);
+    expect(find.text('System Default'), findsOneWidget);
   });
 
-  testWidgets('tapping Get Started navigates to DashboardScreen', (
+  testWidgets('System Default card is pre-selected', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
-    await tester.tap(find.text('Get Started'));
+    // The check_circle icon only appears on the selected card.
+    // There should be exactly one -- on System Default.
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('tapping a theme card selects it', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+    );
+
+    await tester.tap(find.text('Dark'));
+    await tester.pump();
+
+    // After tapping Dark, check_circle moves to the Dark card.
+    // We verify there is still exactly one check_circle (no double-selection).
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+  });
+
+  testWidgets('tapping Continue navigates to DashboardScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+    );
+
+    await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
 
     expect(find.byType(DashboardScreen), findsOneWidget);
   });
 
-  testWidgets('tapping Get Started sets isFirstLaunch to false', (
+  testWidgets('tapping Continue sets isFirstLaunch to false', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
-    await tester.tap(find.text('Get Started'));
+    await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
 
     final Preferences prefs = await Preferences.load();

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -150,27 +150,23 @@ void main() {
       final ProviderContainer container = ProviderContainer();
       addTearDown(container.dispose);
 
-      try {
-        await tester.pumpWidget(
-          UncontrolledProviderScope(
-            container: container,
-            child: const MaterialApp(home: OnboardingScreen()),
-          ),
-        );
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: OnboardingScreen()),
+        ),
+      );
 
-        await tester.tap(find.text('Dark'));
-        await tester.pump();
+      await tester.tap(find.text('Dark'));
+      await tester.pump();
 
-        await tester.tap(find.text('Continue'));
-        await tester.pumpAndSettle();
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
 
-        final AsyncValue<SettingsState> settings = container.read(
-          settingsProvider,
-        );
-        expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
-      } finally {
-        container.dispose();
-      }
+      final AsyncValue<SettingsState> settings = container.read(
+        settingsProvider,
+      );
+      expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
     },
   );
 

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -60,15 +60,10 @@ void main() {
     await tester.tap(find.text('Dark'));
     await tester.pump();
 
-    // After tapping Dark, check_circle must be inside the Dark card's Row,
-    // not just anywhere on screen (passes even if tap did nothing otherwise).
-    final Finder darkCardRow = find.ancestor(
-      of: find.text('Dark'),
-      matching: find.byType(Row),
-    );
+    // After tapping Dark, check_circle must be inside the Dark card only.
     expect(
       find.descendant(
-        of: darkCardRow,
+        of: find.byKey(const ValueKey<ThemeMode>(ThemeMode.dark)),
         matching: find.byIcon(Icons.check_circle),
       ),
       findsOneWidget,
@@ -138,14 +133,10 @@ void main() {
       // Let settingsProvider finish loading so listenManual fires.
       await tester.pumpAndSettle();
 
-      // The Light card should now be selected (check_circle inside its Row).
-      final Finder lightCardRow = find.ancestor(
-        of: find.text('Light'),
-        matching: find.byType(Row),
-      );
+      // The Light card should now be selected (check_circle inside it only).
       expect(
         find.descendant(
-          of: lightCardRow,
+          of: find.byKey(const ValueKey<ThemeMode>(ThemeMode.light)),
           matching: find.byIcon(Icons.check_circle),
         ),
         findsOneWidget,

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -120,6 +120,36 @@ void main() {
   });
 
   testWidgets(
+    'listenManual syncs card when settings load with a stored non-default'
+    ' theme',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'uvalert_theme': 'light',
+      });
+
+      await tester.pumpWidget(
+        const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+      );
+
+      // Let settingsProvider finish loading so listenManual fires.
+      await tester.pumpAndSettle();
+
+      // The Light card should now be selected (check_circle inside its Row).
+      final Finder lightCardRow = find.ancestor(
+        of: find.text('Light'),
+        matching: find.byType(Row),
+      );
+      expect(
+        find.descendant(
+          of: lightCardRow,
+          matching: find.byIcon(Icons.check_circle),
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  testWidgets(
     'tapping Continue persists the selected theme to settingsProvider',
     (WidgetTester tester) async {
       final ProviderContainer container = ProviderContainer();

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -148,6 +148,7 @@ void main() {
     'tapping Continue persists the selected theme to settingsProvider',
     (WidgetTester tester) async {
       final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
 
       try {
         await tester.pumpWidget(

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -18,7 +18,7 @@ void main() {
     // Use a non-const key so the constructor is called at runtime,
     // ensuring the super.key path is traced by the coverage tool.
     final Key key = UniqueKey();
-    
+
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(home: OnboardingScreen(key: key)),
@@ -105,27 +105,29 @@ void main() {
   testWidgets(
     'tapping Continue persists the selected theme to settingsProvider',
     (WidgetTester tester) async {
-    final ProviderContainer container = ProviderContainer();
+      final ProviderContainer container = ProviderContainer();
 
-    try {
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(home: OnboardingScreen()),
-        ),
-      );
+      try {
+        await tester.pumpWidget(
+          UncontrolledProviderScope(
+            container: container,
+            child: const MaterialApp(home: OnboardingScreen()),
+          ),
+        );
 
-      await tester.tap(find.text('Dark'));
-      await tester.pump();
+        await tester.tap(find.text('Dark'));
+        await tester.pump();
 
-      await tester.tap(find.text('Continue'));
-      await tester.pumpAndSettle();
+        await tester.tap(find.text('Continue'));
+        await tester.pumpAndSettle();
 
-      final AsyncValue<SettingsState> settings =
-          container.read(settingsProvider);
-      expect(settings.requireValue.theme, equals('dark'));
-    } finally {
-      container.dispose();
-    }
-  });
+        final AsyncValue<SettingsState> settings = container.read(
+          settingsProvider,
+        );
+        expect(settings.requireValue.theme, equals('dark'));
+      } finally {
+        container.dispose();
+      }
+    },
+  );
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -35,9 +35,7 @@ void main() {
     expect(find.byIcon(Icons.check_circle), findsOneWidget);
   });
 
-  testWidgets('tapping a theme card selects it', (
-    WidgetTester tester,
-  ) async {
+  testWidgets('tapping a theme card selects it', (WidgetTester tester) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -173,4 +173,16 @@ void main() {
       }
     },
   );
+
+  testWidgets('ProgressDots asserts when current is out of range', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(body: ProgressDots(current: 3, total: 3)),
+      ),
+    );
+
+    expect(tester.takeException(), isA<AssertionError>());
+  });
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -82,6 +82,8 @@ void main() {
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
+    await tester.pumpAndSettle();
+
     await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();
 
@@ -94,6 +96,8 @@ void main() {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
+
+    await tester.pumpAndSettle();
 
     await tester.tap(find.text('Continue'));
     await tester.pumpAndSettle();

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -12,6 +12,22 @@ void main() {
     SharedPreferences.setMockInitialValues(<String, Object>{});
   });
 
+  testWidgets('OnboardingScreen constructs with an explicit key', (
+    WidgetTester tester,
+  ) async {
+    // Use a non-const key so the constructor is called at runtime,
+    // ensuring the super.key path is traced by the coverage tool.
+    final Key key = UniqueKey();
+    
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(home: OnboardingScreen(key: key)),
+      ),
+    );
+
+    expect(find.byKey(key), findsOneWidget);
+  });
+
   testWidgets('OnboardingScreen renders all three theme cards', (
     WidgetTester tester,
   ) async {

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -101,17 +101,38 @@ void main() {
     expect(prefs.isFirstLaunch, isFalse);
   });
 
-  testWidgets('tapping Continue writes theme to SharedPreferences', (
+  testWidgets('tapping a card immediately writes theme to settingsProvider', (
+    WidgetTester tester,
+  ) async {
+    final ProviderContainer container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: OnboardingScreen()),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Dark'));
+    await tester.pumpAndSettle();
+
+    final AsyncValue<SettingsState> settings = container.read(settingsProvider);
+    expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
+  });
+
+  testWidgets('tapping a card writes theme to SharedPreferences', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
     );
 
-    await tester.tap(find.text('Dark'));
-    await tester.pump();
+    await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Continue'));
+    await tester.tap(find.text('Dark'));
     await tester.pumpAndSettle();
 
     final Preferences prefs = await Preferences.load();
@@ -145,7 +166,7 @@ void main() {
   );
 
   testWidgets(
-    'tapping Continue persists the selected theme to settingsProvider',
+    'selected theme is in settingsProvider when Continue is tapped',
     (WidgetTester tester) async {
       final ProviderContainer container = ProviderContainer();
       addTearDown(container.dispose);

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -102,6 +102,23 @@ void main() {
     expect(prefs.isFirstLaunch, isFalse);
   });
 
+  testWidgets('tapping Continue writes theme to SharedPreferences', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
+    );
+
+    await tester.tap(find.text('Dark'));
+    await tester.pump();
+
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    final Preferences prefs = await Preferences.load();
+    expect(prefs.theme, ThemeMode.dark);
+  });
+
   testWidgets(
     'tapping Continue persists the selected theme to settingsProvider',
     (WidgetTester tester) async {

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -165,30 +165,26 @@ void main() {
     },
   );
 
-  testWidgets(
-    'selected theme is in settingsProvider when Continue is tapped',
-    (WidgetTester tester) async {
-      final ProviderContainer container = ProviderContainer();
-      addTearDown(container.dispose);
+  testWidgets('selected theme is in settingsProvider when Continue is tapped', (
+    WidgetTester tester,
+  ) async {
+    final ProviderContainer container = ProviderContainer();
+    addTearDown(container.dispose);
 
-      await tester.pumpWidget(
-        UncontrolledProviderScope(
-          container: container,
-          child: const MaterialApp(home: OnboardingScreen()),
-        ),
-      );
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: OnboardingScreen()),
+      ),
+    );
 
-      await tester.tap(find.text('Dark'));
-      await tester.pump();
+    await tester.tap(find.text('Dark'));
+    await tester.pump();
 
-      await tester.tap(find.text('Continue'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
 
-      final AsyncValue<SettingsState> settings = container.read(
-        settingsProvider,
-      );
-      expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
-    },
-  );
-
+    final AsyncValue<SettingsState> settings = container.read(settingsProvider);
+    expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
+  });
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -61,7 +61,7 @@ void main() {
     await tester.pump();
 
     // After tapping Dark, check_circle must be inside the Dark card's Row,
-    // not just anywhere on screen (which would pass even if the tap did nothing).
+    // not just anywhere on screen (passes even if tap did nothing otherwise).
     final Finder darkCardRow = find.ancestor(
       of: find.text('Dark'),
       matching: find.byType(Row),

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -191,15 +191,4 @@ void main() {
     },
   );
 
-  testWidgets('ProgressDots asserts when current is out of range', (
-    WidgetTester tester,
-  ) async {
-    await tester.pumpWidget(
-      const MaterialApp(
-        home: Scaffold(body: ProgressDots(current: 3, total: 3)),
-      ),
-    );
-
-    expect(tester.takeException(), isA<AssertionError>());
-  });
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
@@ -73,5 +74,32 @@ void main() {
 
     final Preferences prefs = await Preferences.load();
     expect(prefs.isFirstLaunch, isFalse);
+  });
+
+  testWidgets(
+    'tapping Continue persists the selected theme to settingsProvider',
+    (WidgetTester tester) async {
+    final ProviderContainer container = ProviderContainer();
+
+    try {
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const MaterialApp(home: OnboardingScreen()),
+        ),
+      );
+
+      await tester.tap(find.text('Dark'));
+      await tester.pump();
+
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      final AsyncValue<SettingsState> settings =
+          container.read(settingsProvider);
+      expect(settings.requireValue.theme, equals('dark'));
+    } finally {
+      container.dispose();
+    }
   });
 }

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -140,8 +140,7 @@ void main() {
   });
 
   testWidgets(
-    'listenManual syncs card when settings load with a stored non-default'
-    ' theme',
+    'card reflects stored non-default theme once settingsProvider loads',
     (WidgetTester tester) async {
       SharedPreferences.setMockInitialValues(<String, Object>{
         'uvalert_theme': 'light',
@@ -151,7 +150,7 @@ void main() {
         const ProviderScope(child: MaterialApp(home: OnboardingScreen())),
       );
 
-      // Let settingsProvider finish loading so listenManual fires.
+      // Let settingsProvider finish loading so the card reflects stored theme.
       await tester.pumpAndSettle();
 
       // The Light card should now be selected (check_circle inside it only).

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -124,7 +124,7 @@ void main() {
         final AsyncValue<SettingsState> settings = container.read(
           settingsProvider,
         );
-        expect(settings.requireValue.theme, equals('dark'));
+        expect(settings.requireValue.themeMode, equals(ThemeMode.dark));
       } finally {
         container.dispose();
       }

--- a/test/preferences_test.dart
+++ b/test/preferences_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
@@ -23,7 +24,7 @@ void main() {
 
     test('theme defaults to system', () async {
       final Preferences prefs = await Preferences.load();
-      expect(prefs.theme, 'system');
+      expect(prefs.theme, ThemeMode.system);
     });
 
     test('useGps defaults to true', () async {
@@ -72,8 +73,8 @@ void main() {
 
     test('setTheme stores and retrieves theme', () async {
       final Preferences prefs = await Preferences.load();
-      await prefs.setTheme('dark');
-      expect(prefs.theme, 'dark');
+      await prefs.setTheme(ThemeMode.dark);
+      expect(prefs.theme, ThemeMode.dark);
     });
 
     test('setUseGps toggles value', () async {
@@ -142,7 +143,7 @@ void main() {
     test('clearAll resets all values to defaults', () async {
       final Preferences prefs = await Preferences.load();
       await prefs.setUuid('abc');
-      await prefs.setTheme('dark');
+      await prefs.setTheme(ThemeMode.dark);
       await prefs.setUseGps(value: false);
       await prefs.setManualLocation('Boston');
       await prefs.setNotificationsEnabled(value: true);
@@ -153,7 +154,7 @@ void main() {
       await prefs.clearAll();
 
       expect(prefs.uuid, isNull);
-      expect(prefs.theme, 'system');
+      expect(prefs.theme, ThemeMode.system);
       expect(prefs.useGps, isTrue);
       expect(prefs.manualLocation, isNull);
       expect(prefs.notificationsEnabled, isFalse);

--- a/test/settings_provider_test.dart
+++ b/test/settings_provider_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -45,7 +46,7 @@ void main() {
     final SettingsState settings = container
         .read(settingsProvider)
         .requireValue;
-    expect(settings.theme, 'system');
+    expect(settings.themeMode, ThemeMode.system);
     expect(settings.useGps, isTrue);
     expect(settings.manualLocation, isNull);
     expect(settings.notificationsEnabled, isFalse);
@@ -73,21 +74,15 @@ void main() {
   // setTheme
   // -------------------------------------------------------------------------
 
-  test('setTheme rejects invalid theme value', () async {
+  test('setTheme updates themeMode in state', () async {
     final ProviderContainer container = await _makeLoadedContainer();
+
+    await container.read(settingsProvider.notifier).setTheme(ThemeMode.dark);
 
     expect(
-      () => container.read(settingsProvider.notifier).setTheme('invalid'),
-      throwsA(isA<AssertionError>()),
+      container.read(settingsProvider).requireValue.themeMode,
+      ThemeMode.dark,
     );
-  });
-
-  test('setTheme updates theme in state', () async {
-    final ProviderContainer container = await _makeLoadedContainer();
-
-    await container.read(settingsProvider.notifier).setTheme('dark');
-
-    expect(container.read(settingsProvider).requireValue.theme, 'dark');
   });
 
   // -------------------------------------------------------------------------
@@ -148,12 +143,12 @@ void main() {
     final SettingsNotifier notifier = container.read(settingsProvider.notifier);
 
     await Future.wait(<Future<void>>[
-      notifier.setTheme('dark'),
+      notifier.setTheme(ThemeMode.dark),
       notifier.setUseGps(value: false),
     ]);
 
     final SettingsState result = container.read(settingsProvider).requireValue;
-    expect(result.theme, 'dark');
+    expect(result.themeMode, ThemeMode.dark);
     expect(result.useGps, isFalse);
   });
 }


### PR DESCRIPTION
Closes #13

## Features

- Implemented theme selection screen (screen 1 of onboarding): Light, Dark, and System Default cards; System Default pre-selected; theme applies immediately on tap
- Added progress indicator (3 dots) via `_ProgressDots` with assertion-guarded index validation
- Continue button enabled only when `settingsProvider` is ready
- Theme selection persists to `SharedPreferences` via `settingsProvider`
- Added theme handling in `UvAlertApp` with separate light and dark `ThemeData` definitions
- Added accessibility semantics to theme cards

## Bug Fixes

- Prevented multiple continue taps during onboarding navigation
- Prevented multiple theme selections firing concurrently
- Handled settings error state in theme selection
- Ensured `preferencesProvider` is invalidated after `setFirstLaunchDone()`
- Cleared optimistic theme override only when not superseded by a newer selection
- Changed `onTap` type from `Future<void> Function()` to `VoidCallback` for consistency

## Refactoring

- Converted `OnboardingScreen` to `ConsumerStatefulWidget` for provider access
- Initialized `selectedTheme` from `settingsProvider` on screen load; synced state after settings load
- Changed theme selection to await async setting application
- Replaced `GestureDetector` with `InkWell` for improved tap handling
- Replaced hardcoded values with named constants; used constant for total onboarding steps
- Renamed `theme` to `themeMode` in `SettingsNotifier` and updated related methods
- Optimized theme mode retrieval in `Preferences` by caching the theme mode mapping
- Simplified theme mode selection logic, state management, and onboarding completion logic
- Moved `preferencesProvider` invalidation to maintain state consistency
- Restructured theme card rendering and separated light/dark theme definitions in `app.dart`

## Tests

- Tests for theme card selection, immediate provider update on tap, and navigation to `DashboardScreen`
- Test for theme selection persistence to `SharedPreferences`
- Test for theme selection state on settings load
- Test for `OnboardingScreen` construction with explicit key
- Updated test description for theme card reflection on settings load
- Added explicit `ProviderContainer` teardown in all test cases

## Docs / Style

- Updated TODO in `_ProgressDots` to reference new issue number for active dot animation
- Clarified comments on optimistic writes, loading state, and theme persistence
- Updated TODO comment to specify location screen flow
- Added comment on `ColorScheme.fromSeed` performance in `app.dart`
- Removed obsolete comment about onboarding screen index
- Simplified assertion message in `_ProgressDots`

## Notes

Onboarding flow: Theme → Location → Notifications → Dashboard. This PR implements screen 1 only. Continue temporarily navigates to `DashboardScreen` until the location screen (issue #14) is built.