### PR TITLE
feat(onboarding): add notification onboarding screen and update routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,14 +143,15 @@ without mocks leaking across boundaries.
 - `theme_onboarding_screen.dart` -- step 1: theme selection; calls
   `prefs.setThemeStepDone()`; does NOT call `setFirstLaunchDone()`
 - `location_onboarding_screen.dart` -- step 2: GPS or manual entry via
-  geocoding; calls `setFirstLaunchDone()` after all data is written
+  geocoding; navigates to `NotificationOnboardingScreen`
+- `notification_onboarding_screen.dart` -- step 3: notification
+  preference (Default or None); calls `setFirstLaunchDone()` then
+  navigates to `DashboardScreen`
 - `dashboard_screen.dart` -- placeholder only
 - `onboarding_progress_dots.dart` -- shared progress indicator widget
 
 ### Not yet implemented
 
-- Onboarding step 3 (notifications, issue #15) -- when added, move
-  `setFirstLaunchDone()` there and bump `totalOnboardingSteps` to 3
 - Real dashboard screen and settings screen
 - `lib/services/` (background polling via `workmanager`, local
   notifications via `flutter_local_notifications`)

--- a/README.md
+++ b/README.md
@@ -187,10 +187,9 @@ Used for both `hourly` (48 h) and `daily` (8 d) lists.
 
 Required for running the Flutter Linux desktop target under Xvfb
 
-```sh
-pgrep -x Xvfb >/dev/null || Xvfb :99 -screen 0 1280x1024x24 -ac &
-sleep 0.5
-export DISPLAY=:99
+```fish
+pgrep -x Xvfb >/dev/null; or (Xvfb :99 -screen 0 1280x1024x24 -ac &; sleep 0.5)
+set -x DISPLAY :99
 ```
 
 ## Running Tests

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ flutter pub get                                    # Install dependencies
 flutter analyze --fatal-infos                      # Lint (very_good_analysis)
 flutter test --exclude-tags integration            # Run all unit/widget tests
 flutter test test/foo_test.dart                    # Run a single test file
-flutter pub global run dartdoc                     # Generate and validate API docs
+dart doc --validate-links                          # Generate and validate API docs
 flutter build apk                                  # Android APK
 flutter build appbundle                            # Android App Bundle
 ```

--- a/README.md
+++ b/README.md
@@ -40,18 +40,30 @@ flutter run
 
 ## Commands
 
-```sh
-flutter pub get                       # Install dependencies
-flutter analyze                       # Lint (very_good_analysis)
-flutter test                          # Run all tests
-flutter test test/foo_test.dart       # Run a single test file
-flutter pub global run dartdoc        # Generate and validate API docs
-flutter build apk                     # Android APK
-flutter build appbundle               # Android App Bundle
+```fish
+flutter pub get                                    # Install dependencies
+flutter analyze --fatal-infos                      # Lint (very_good_analysis)
+flutter test --exclude-tags integration            # Run all unit/widget tests
+flutter test test/foo_test.dart                    # Run a single test file
+flutter pub global run dartdoc                     # Generate and validate API docs
+flutter build apk                                  # Android APK
+flutter build appbundle                            # Android App Bundle
 ```
 
-CI runs `flutter analyze --fatal-infos` and `dart doc --validate-links`
-as required gates. Run both locally before any PR.
+Integration tests (require live proxy):
+
+```fish
+flutter test --tags integration test/integration/geocoding_api_live_test.dart
+```
+
+Run `flutter analyze --fatal-infos` and `dart doc --validate-links` locally
+before any PR.
+
+### Full guidance
+
+All architecture, data-flow, provider graph, screen specs, preferences keys,
+CI/CD, and style rules are documented in `.private/CLAUDE.md`. Read it before
+reasoning about any design decision.
 
 ## Architecture
 
@@ -185,11 +197,12 @@ Used for both `hourly` (48 h) and `daily` (8 d) lists.
 
 ## Headless display (Linux)
 
-Required for running the Flutter Linux desktop target under Xvfb
+Required for running the Flutter Linux desktop target under Xvfb:
 
 ```fish
 pgrep -x Xvfb >/dev/null; or (Xvfb :99 -screen 0 1280x1024x24 -ac &; sleep 0.5)
 set -x DISPLAY :99
+flutter run -d linux --dart-define=PROXY_BASE_URL=https://uv-alert-proxy.vercel.app
 ```
 
 ## Running Tests
@@ -244,8 +257,8 @@ Additional style rules:
   (`always_specify_types: true`)
 - All numeric literals must be named constants -- no magic numbers, no
   single-use exemptions
-- Single quotes for strings; double quotes only when the string
-  contains a single quote (`prefer_single_quotes` lint rule)
+- Double quotes for strings; single quotes only when the string
+  contains a double quote
 - File-private helpers go at file scope with `_` prefix, not as static
   methods
 - Trailing commas are managed by the formatter

--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ without mocks leaking across boundaries.
   kick off async initialization.
 - Unawaited `Navigator` push calls must be wrapped in `unawaited()`
   (required by `unawaited_futures` + `discarded_futures` lint rules).
+- `setFirstLaunchDone()` is owned by the **last** onboarding screen
+  (`NotificationOnboardingScreen`); move it forward when a new screen
+  is appended.
 
 ### Screens (`lib/screens/`)
 
@@ -179,6 +182,16 @@ Used for both `hourly` (48 h) and `daily` (8 d) lists.
 | `notifications_enabled` | `bool` | `false` |
 | `cached_payload` | `String?` | -- |
 | `cached_payload_at` | `String?` | -- |
+
+## Headless display (Linux)
+
+Required for running the Flutter Linux desktop target under Xvfb
+
+```sh
+pgrep -x Xvfb >/dev/null || Xvfb :99 -screen 0 1280x1024x24 -ac &
+sleep 0.5
+export DISPLAY=:99
+```
 
 ## Running Tests
 
@@ -232,8 +245,8 @@ Additional style rules:
   (`always_specify_types: true`)
 - All numeric literals must be named constants -- no magic numbers, no
   single-use exemptions
-- Double quotes for strings; single quotes only when the string
-  contains a double quote
+- Single quotes for strings; double quotes only when the string
+  contains a single quote (`prefer_single_quotes` lint rule)
 - File-private helpers go at file scope with `_` prefix, not as static
   methods
 - Trailing commas are managed by the formatter

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,2 +1,4 @@
+timeout: 60s
+
 tags:
   integration: {}

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -52,8 +52,9 @@ class GeocodingApi {
   /// candidate matches, ordered by relevance.
   ///
   /// Returns between 1 and 5 results. Throws [GeocodingNotFoundException]
-  /// when the proxy returns 404 (no match). Throws [GeocodingException] on
-  /// any other non-200 response or parse error.
+  /// when the proxy returns 404 (no match) or the response contains no
+  /// usable results. Throws [GeocodingException] on any other non-200
+  /// response or parse error.
   Future<List<GeocodingResult>> geocodeMultiple(String query) async {
     final Uri uri = _geocodeUri.replace(
       queryParameters: <String, String>{'q': query},
@@ -89,13 +90,7 @@ class GeocodingApi {
   }
 
   List<GeocodingResult> _parseResults(http.Response response) {
-    if (response.statusCode == httpNotFound) {
-      throw const GeocodingNotFoundException();
-    }
-
-    if (response.statusCode != httpOk) {
-      throw GeocodingException(response.statusCode, response.body);
-    }
+    _checkStatus(response);
 
     try {
       final Object? decoded = jsonDecode(response.body);
@@ -109,32 +104,12 @@ class GeocodingApi {
       for (final Object? item in decoded) {
         if (item is! Map<String, Object?>) continue;
 
-        final Object? lat = item['lat'];
-        final Object? lon = item['lon'];
-        final Object? name = item['name'];
-        final Object? country = item['country'];
-        final Object? state = item['state'];
-
-        if (lat is! num ||
-            lon is! num ||
-            name is! String ||
-            country is! String) {
-          continue;
-        }
-
-        final String displayName = state is String
-            ? '$name, $state, $country'
-            : '$name, $country';
-
-        results.add((
-          lat: lat.toDouble(),
-          lon: lon.toDouble(),
-          displayName: displayName,
-        ));
+        final GeocodingResult? result = _itemToResult(item);
+        if (result != null) results.add(result);
       }
 
       if (results.isEmpty) {
-        throw GeocodingException(response.statusCode, response.body);
+        throw const GeocodingNotFoundException();
       }
 
       return results;
@@ -144,13 +119,7 @@ class GeocodingApi {
   }
 
   GeocodingResult _parseResult(http.Response response) {
-    if (response.statusCode == httpNotFound) {
-      throw const GeocodingNotFoundException();
-    }
-
-    if (response.statusCode != httpOk) {
-      throw GeocodingException(response.statusCode, response.body);
-    }
+    _checkStatus(response);
 
     try {
       final Object? decoded = jsonDecode(response.body);
@@ -159,29 +128,46 @@ class GeocodingApi {
         throw GeocodingException(response.statusCode, response.body);
       }
 
-      final Object? lat = decoded['lat'];
-      final Object? lon = decoded['lon'];
-      final Object? name = decoded['name'];
-      final Object? country = decoded['country'];
-      final Object? state = decoded['state'];
-
-      if (lat is! num || lon is! num || name is! String || country is! String) {
+      final GeocodingResult? result = _itemToResult(decoded);
+      if (result == null) {
         throw GeocodingException(response.statusCode, response.body);
       }
 
-      final String displayName = state is String
-          ? '$name, $state, $country'
-          : '$name, $country';
-
-      return (
-        lat: lat.toDouble(),
-        lon: lon.toDouble(),
-        displayName: displayName,
-      );
+      return result;
     } on FormatException catch (e) {
       throw GeocodingException(response.statusCode, 'parse error: $e');
     }
   }
+
+}
+
+void _checkStatus(http.Response response) {
+  if (response.statusCode == httpNotFound) {
+    throw const GeocodingNotFoundException();
+  }
+  if (response.statusCode != httpOk) {
+    throw GeocodingException(response.statusCode, response.body);
+  }
+}
+
+/// Parses one JSON object into a [GeocodingResult], or returns `null` if
+/// required fields are missing or have the wrong type.
+GeocodingResult? _itemToResult(Map<String, Object?> item) {
+  final Object? lat = item['lat'];
+  final Object? lon = item['lon'];
+  final Object? name = item['name'];
+  final Object? country = item['country'];
+  final Object? state = item['state'];
+
+  if (lat is! num || lon is! num || name is! String || country is! String) {
+    return null;
+  }
+
+  final String displayName = state is String
+      ? '$name, $state, $country'
+      : '$name, $country';
+
+  return (lat: lat.toDouble(), lon: lon.toDouble(), displayName: displayName);
 }
 
 /// Thrown when the proxy returns 404 (location not found).

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -165,10 +165,7 @@ class GeocodingApi {
       final Object? country = decoded['country'];
       final Object? state = decoded['state'];
 
-      if (lat is! num ||
-          lon is! num ||
-          name is! String ||
-          country is! String) {
+      if (lat is! num || lon is! num || name is! String || country is! String) {
         throw GeocodingException(response.statusCode, response.body);
       }
 

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -48,12 +48,13 @@ class GeocodingApi {
     if (_ownsClient) _httpClient.close();
   }
 
-  /// Resolves a location [query] string (e.g. "Fresno") to coordinates
-  /// and a human-readable display name.
+  /// Resolves a location [query] string (e.g. "Fresno") to a list of
+  /// candidate matches, ordered by relevance.
   ///
-  /// Throws [GeocodingNotFoundException] when the proxy returns 404 (no match).
-  /// Throws [GeocodingException] on any other non-200 response or parse error.
-  Future<GeocodingResult> geocode(String query) async {
+  /// Returns between 1 and 5 results. Throws [GeocodingNotFoundException]
+  /// when the proxy returns 404 (no match). Throws [GeocodingException] on
+  /// any other non-200 response or parse error.
+  Future<List<GeocodingResult>> geocodeMultiple(String query) async {
     final Uri uri = _geocodeUri.replace(
       queryParameters: <String, String>{'q': query},
     );
@@ -62,7 +63,7 @@ class GeocodingApi {
         .get(uri, headers: _headers)
         .timeout(_timeout);
 
-    return _parseResult(response);
+    return _parseResults(response);
   }
 
   /// Resolves GPS [lat]/[lon] coordinates to a human-readable display name.
@@ -87,6 +88,61 @@ class GeocodingApi {
     return _parseResult(response);
   }
 
+  List<GeocodingResult> _parseResults(http.Response response) {
+    if (response.statusCode == httpNotFound) {
+      throw const GeocodingNotFoundException();
+    }
+
+    if (response.statusCode != httpOk) {
+      throw GeocodingException(response.statusCode, response.body);
+    }
+
+    try {
+      final Object? decoded = jsonDecode(response.body);
+
+      if (decoded is! List<Object?>) {
+        throw GeocodingException(response.statusCode, response.body);
+      }
+
+      final List<GeocodingResult> results = <GeocodingResult>[];
+
+      for (final Object? item in decoded) {
+        if (item is! Map<String, Object?>) continue;
+
+        final Object? lat = item['lat'];
+        final Object? lon = item['lon'];
+        final Object? name = item['name'];
+        final Object? country = item['country'];
+        final Object? state = item['state'];
+
+        if (lat is! num ||
+            lon is! num ||
+            name is! String ||
+            country is! String) {
+          continue;
+        }
+
+        final String displayName = state is String
+            ? '$name, $state, $country'
+            : '$name, $country';
+
+        results.add((
+          lat: lat.toDouble(),
+          lon: lon.toDouble(),
+          displayName: displayName,
+        ));
+      }
+
+      if (results.isEmpty) {
+        throw GeocodingException(response.statusCode, response.body);
+      }
+
+      return results;
+    } on FormatException catch (e) {
+      throw GeocodingException(response.statusCode, 'parse error: $e');
+    }
+  }
+
   GeocodingResult _parseResult(http.Response response) {
     if (response.statusCode == httpNotFound) {
       throw const GeocodingNotFoundException();
@@ -109,7 +165,10 @@ class GeocodingApi {
       final Object? country = decoded['country'];
       final Object? state = decoded['state'];
 
-      if (lat is! num || lon is! num || name is! String || country is! String) {
+      if (lat is! num ||
+          lon is! num ||
+          name is! String ||
+          country is! String) {
         throw GeocodingException(response.statusCode, response.body);
       }
 

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -139,35 +139,34 @@ class GeocodingApi {
     }
   }
 
-}
-
-void _checkStatus(http.Response response) {
-  if (response.statusCode == httpNotFound) {
-    throw const GeocodingNotFoundException();
-  }
-  if (response.statusCode != httpOk) {
-    throw GeocodingException(response.statusCode, response.body);
-  }
-}
-
-/// Parses one JSON object into a [GeocodingResult], or returns `null` if
-/// required fields are missing or have the wrong type.
-GeocodingResult? _itemToResult(Map<String, Object?> item) {
-  final Object? lat = item['lat'];
-  final Object? lon = item['lon'];
-  final Object? name = item['name'];
-  final Object? country = item['country'];
-  final Object? state = item['state'];
-
-  if (lat is! num || lon is! num || name is! String || country is! String) {
-    return null;
+  static void _checkStatus(http.Response response) {
+    if (response.statusCode == httpNotFound) {
+      throw const GeocodingNotFoundException();
+    }
+    if (response.statusCode != httpOk) {
+      throw GeocodingException(response.statusCode, response.body);
+    }
   }
 
-  final String displayName = state is String
-      ? '$name, $state, $country'
-      : '$name, $country';
+  /// Parses one JSON object into a [GeocodingResult], or returns `null` if
+  /// required fields are missing or have the wrong type.
+  static GeocodingResult? _itemToResult(Map<String, Object?> item) {
+    final Object? lat = item['lat'];
+    final Object? lon = item['lon'];
+    final Object? name = item['name'];
+    final Object? country = item['country'];
+    final Object? state = item['state'];
 
-  return (lat: lat.toDouble(), lon: lon.toDouble(), displayName: displayName);
+    if (lat is! num || lon is! num || name is! String || country is! String) {
+      return null;
+    }
+
+    final String displayName = state is String
+        ? '$name, $state, $country'
+        : '$name, $country';
+
+    return (lat: lat.toDouble(), lon: lon.toDouble(), displayName: displayName);
+  }
 }
 
 /// Thrown when the proxy returns 404 (location not found).

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -51,7 +51,7 @@ class GeocodingApi {
   /// Resolves a location [query] string (e.g. "Fresno") to a list of
   /// candidate matches, ordered by relevance.
   ///
-  /// Returns between 1 and 5 results. Throws [GeocodingNotFoundException]
+  /// Returns one or more results. Throws [GeocodingNotFoundException]
   /// when the proxy returns 404 (no match) or the response contains no
   /// usable results. Throws [GeocodingException] on any other non-200
   /// response or parse error.

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -18,6 +18,12 @@ const String deviceIdHeader = 'X-Device-ID';
 /// Default HTTP request timeout for all API clients.
 const Duration apiDefaultTimeout = Duration(seconds: 10);
 
+/// Timeout for GPS hardware acquisition.
+///
+/// Separate from [apiDefaultTimeout] because GPS cold-start can legitimately
+/// take longer than a network roundtrip (weak signal, first fix indoors).
+const Duration gpsTimeout = Duration(seconds: 30);
+
 /// HTTP 200 OK status code.
 const int httpOk = 200;
 
@@ -61,3 +67,10 @@ const double onboardingItemGap = 12;
 
 /// Gap between a card's label and its description line.
 const double onboardingLabelGap = 4;
+
+/// Card corner radius used across all onboarding screens.
+///
+/// Derived from [onboardingCardBorderRadius].
+const BorderRadius onboardingCardRadius = BorderRadius.all(
+  Radius.circular(onboardingCardBorderRadius),
+);

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -52,3 +52,12 @@ const double onboardingSelectedBorderWidth = 2;
 
 /// Background fill opacity for a selected card on onboarding screens.
 const double onboardingSelectedCardOpacity = 0.08;
+
+/// Gap between major sections within an onboarding screen.
+const double onboardingSectionGap = 24;
+
+/// Gap between items within an onboarding card or section.
+const double onboardingItemGap = 12;
+
+/// Gap between a card's label and its description line.
+const double onboardingLabelGap = 4;

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -68,6 +68,10 @@ const double onboardingItemGap = 12;
 /// Gap between a card's label and its description line.
 const double onboardingLabelGap = 4;
 
+/// Maximum fraction of screen height the pick-list candidate scroll area
+/// may occupy.
+const double onboardingPickListMaxHeightFraction = 0.35;
+
 /// Card corner radius used across all onboarding screens.
 ///
 /// Derived from [onboardingCardBorderRadius].

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 const int msPerSecond = 1000;
 
 /// Total number of onboarding steps shown in the progress indicator.
-const int totalOnboardingSteps = 2;
+const int totalOnboardingSteps = 3;
 
 /// Brand periwinkle drawn from the logo's actual color (#9498ED).
 const Color logoPurple = Color(0xFF9498ED);

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:uvalert/constants.dart';
 
 /// Latitude/longitude pair; `null` until a location is acquired.
 typedef LocationState = ({double lat, double lon})?;
@@ -33,11 +34,13 @@ class LocationNotifier extends Notifier<LocationState> {
       throw const PermissionDeniedException('Location permission denied.');
     }
 
-    final Position position = await _platform.getCurrentPosition(
-      locationSettings: const LocationSettings(
-        accuracy: LocationAccuracy.medium,
-      ),
-    );
+    final Position position = await _platform
+        .getCurrentPosition(
+          locationSettings: const LocationSettings(
+            accuracy: LocationAccuracy.medium,
+          ),
+        )
+        .timeout(apiDefaultTimeout);
 
     state = (lat: position.latitude, lon: position.longitude);
   }

--- a/lib/providers/location_provider.dart
+++ b/lib/providers/location_provider.dart
@@ -40,7 +40,7 @@ class LocationNotifier extends Notifier<LocationState> {
             accuracy: LocationAccuracy.medium,
           ),
         )
-        .timeout(apiDefaultTimeout);
+        .timeout(gpsTimeout);
 
     state = (lat: position.latitude, lon: position.longitude);
   }

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -8,10 +8,12 @@ import 'package:uvalert/api/geocoding_api.dart';
 import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/device_id_provider.dart';
 import 'package:uvalert/providers/location_provider.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
+import 'package:uvalert/storage/preferences.dart';
 
 // ---------------------------------------------------------------------------
 // Layout constants
@@ -129,17 +131,24 @@ class _LocationOnboardingScreenState
         return;
       }
 
-      final GeocodingResult result = await _geocodingApi(
-        proxyBaseUrl,
-        deviceId,
-      ).reverseGeocode(lat: loc.lat, lon: loc.lon);
+      // Inner try/catch isolates the HTTP timeout from the GPS timeout above.
+      // Both throw TimeoutException but require different error messages.
+      GeocodingResult result;
+
+      try {
+        result = await _geocodingApi(
+          proxyBaseUrl,
+          deviceId,
+        ).reverseGeocode(lat: loc.lat, lon: loc.lon);
+      } on TimeoutException {
+        if (!mounted) return;
+        _setError('Could not determine your city. Try entering it manually.');
+        return;
+      }
 
       if (!mounted) return;
 
-      setState(() {
-        _pending = (result: result, fromGps: true);
-        _phase = _Phase.confirm;
-      });
+      _setConfirmed(result, fromGps: true);
     } on PermissionDeniedException {
       if (!mounted) return;
       // Permission denied; fall through to manual entry.
@@ -191,10 +200,7 @@ class _LocationOnboardingScreenState
       if (!mounted) return;
 
       if (results.length == 1) {
-        setState(() {
-          _pending = (result: results.first, fromGps: false);
-          _phase = _Phase.confirm;
-        });
+        _setConfirmed(results.first, fromGps: false);
       } else {
         setState(() {
           _candidates = results;
@@ -218,13 +224,18 @@ class _LocationOnboardingScreenState
     }
   }
 
-  void _onPickCandidate(GeocodingResult result) {
+  void _setConfirmed(GeocodingResult result, {required bool fromGps}) {
     setState(() {
       _candidates = <GeocodingResult>[];
-      _pending = (result: result, fromGps: false);
+      _pending = (result: result, fromGps: fromGps);
       _phase = _Phase.confirm;
     });
   }
+
+  void _onPickCandidate(GeocodingResult result) => _setConfirmed(
+    result,
+    fromGps: false,
+  );
 
   void _onSearchAgain() {
     setState(() {
@@ -257,6 +268,9 @@ class _LocationOnboardingScreenState
       ref
           .read(locationProvider.notifier)
           .setManual(lat: confirmed.result.lat, lon: confirmed.result.lon);
+
+      final Preferences prefs = await ref.read(preferencesProvider.future);
+      await prefs.setLocationStepDone();
 
       if (!mounted) return;
 
@@ -395,18 +409,19 @@ class _Header extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return Column(
       spacing: onboardingItemGap,
       children: <Widget>[
         Text(
           'Your Location',
-          style: Theme.of(context).textTheme.headlineMedium,
+          style: theme.textTheme.headlineMedium,
         ),
         Text(
           'UV Alert uses your location to provide accurate UV readings '
           'for your area.',
           textAlign: TextAlign.center,
-          style: Theme.of(context).textTheme.bodyMedium,
+          style: theme.textTheme.bodyMedium,
         ),
       ],
     );
@@ -503,10 +518,8 @@ class _ConfirmCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final ColorScheme colors = Theme.of(context).colorScheme;
-    final BorderRadius radius = BorderRadius.circular(
-      onboardingCardBorderRadius,
-    );
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
 
     return Container(
       padding: const EdgeInsets.symmetric(
@@ -514,7 +527,7 @@ class _ConfirmCard extends StatelessWidget {
         vertical: onboardingCardPaddingVertical,
       ),
       decoration: BoxDecoration(
-        borderRadius: radius,
+        borderRadius: onboardingCardRadius,
         border: Border.all(
           color: colors.primary,
           width: onboardingSelectedBorderWidth,
@@ -531,9 +544,9 @@ class _ConfirmCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   displayName,
-                  style: Theme.of(
-                    context,
-                  ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                  style: theme.textTheme.bodyLarge?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
                 ),
               ),
             ],
@@ -541,9 +554,9 @@ class _ConfirmCard extends StatelessWidget {
           Text(
             'Location is approximate and may vary based on device GPS '
             'accuracy, network conditions, or other factors.',
-            style: Theme.of(
-              context,
-            ).textTheme.bodySmall?.copyWith(color: colors.onSurfaceVariant),
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colors.onSurfaceVariant,
+            ),
           ),
           Row(
             mainAxisAlignment: MainAxisAlignment.end,
@@ -570,13 +583,14 @@ class _PickList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       spacing: onboardingItemGap,
       children: <Widget>[
         Text(
           'Select your location:',
-          style: Theme.of(context).textTheme.bodyMedium,
+          style: theme.textTheme.bodyMedium,
         ),
         ...candidates.map(
           (GeocodingResult r) => OutlinedButton(
@@ -587,8 +601,8 @@ class _PickList extends StatelessWidget {
         Text(
           'Not your city? Try adding region and country'
           ' (e.g. "Washington, DC, US" or "London, England, GB").',
-          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
           ),
           textAlign: TextAlign.center,
         ),
@@ -605,10 +619,11 @@ class _ErrorText extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
     return Text(
       message,
-      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-        color: Theme.of(context).colorScheme.error,
+      style: theme.textTheme.bodyMedium?.copyWith(
+        color: theme.colorScheme.error,
       ),
       textAlign: TextAlign.center,
     );

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -7,7 +7,6 @@ import 'package:uvalert/api/geocoding_api.dart';
 import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/device_id_provider.dart';
 import 'package:uvalert/providers/location_provider.dart';
-import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
@@ -18,8 +17,6 @@ import 'package:uvalert/screens/onboarding_progress_dots.dart';
 // ---------------------------------------------------------------------------
 const int _locationScreenIndex = 1;
 
-const double _sectionGap = 24;
-const double _itemGap = 12;
 const double _spinnerSize = 16;
 const double _spinnerStrokeWidth = 2;
 
@@ -230,8 +227,6 @@ class _LocationOnboardingScreenState
 
       if (!mounted) return;
 
-      ref.invalidate(preferencesProvider);
-
       unawaited(
         Navigator.of(context).pushReplacement(
           MaterialPageRoute<void>(
@@ -296,7 +291,7 @@ class _LocationOnboardingScreenState
             vertical: onboardingPaddingVertical,
           ),
           child: Column(
-            spacing: _sectionGap,
+            spacing: onboardingSectionGap,
             children: <Widget>[
               const Spacer(),
 
@@ -361,7 +356,7 @@ class _Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(
-      spacing: _itemGap,
+      spacing: onboardingItemGap,
       children: <Widget>[
         Text(
           'Your Location',
@@ -442,7 +437,7 @@ class _ManualEntryField extends StatelessWidget {
         border: const OutlineInputBorder(),
         suffixIcon: loading
             ? const Padding(
-                padding: EdgeInsets.all(_itemGap),
+                padding: EdgeInsets.all(onboardingItemGap),
                 child: SizedBox.square(
                   dimension: _spinnerSize,
                   child: CircularProgressIndicator.adaptive(
@@ -487,12 +482,12 @@ class _ConfirmCard extends StatelessWidget {
         color: colors.primary.withValues(alpha: onboardingSelectedCardOpacity),
       ),
       child: Column(
-        spacing: _itemGap,
+        spacing: onboardingItemGap,
         children: <Widget>[
           Row(
             children: <Widget>[
               Icon(Icons.location_on, color: colors.primary),
-              const SizedBox(width: _itemGap),
+              const SizedBox(width: onboardingItemGap),
               Expanded(
                 child: Text(
                   displayName,

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -234,7 +234,6 @@ class _LocationOnboardingScreenState
 
   void _onSearchAgain() {
     setState(() {
-      _candidates = <GeocodingResult>[];
       _phase = _Phase.manual;
     });
     _manualFocus.requestFocus();
@@ -581,7 +580,6 @@ class _PickList extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     return Column(
-      crossAxisAlignment: CrossAxisAlignment.stretch,
       spacing: onboardingItemGap,
       children: <Widget>[
         Text(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -408,10 +408,7 @@ class _Header extends StatelessWidget {
     return Column(
       spacing: onboardingItemGap,
       children: <Widget>[
-        Text(
-          'Your Location',
-          style: theme.textTheme.headlineMedium,
-        ),
+        Text('Your Location', style: theme.textTheme.headlineMedium),
         Text(
           'UV Alert uses your location to provide accurate UV readings '
           'for your area.',
@@ -582,10 +579,7 @@ class _PickList extends StatelessWidget {
     return Column(
       spacing: onboardingItemGap,
       children: <Widget>[
-        Text(
-          'Select your location:',
-          style: theme.textTheme.bodyMedium,
-        ),
+        Text('Select your location:', style: theme.textTheme.bodyMedium),
         ...candidates.map(
           (GeocodingResult r) => OutlinedButton(
             onPressed: () => onPick(r),

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -232,11 +232,6 @@ class _LocationOnboardingScreenState
     });
   }
 
-  void _onPickCandidate(GeocodingResult result) => _setConfirmed(
-    result,
-    fromGps: false,
-  );
-
   void _onSearchAgain() {
     setState(() {
       _candidates = <GeocodingResult>[];
@@ -363,7 +358,8 @@ class _LocationOnboardingScreenState
               if (_phase == _Phase.picking)
                 _PickList(
                   candidates: _candidates,
-                  onPick: _onPickCandidate,
+                  onPick: (GeocodingResult r) =>
+                      _setConfirmed(r, fromGps: false),
                   onSearchAgain: _onSearchAgain,
                 ),
 

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -580,10 +580,24 @@ class _PickList extends StatelessWidget {
       spacing: onboardingItemGap,
       children: <Widget>[
         Text('Select your location:', style: theme.textTheme.bodyMedium),
-        ...candidates.map(
-          (GeocodingResult r) => OutlinedButton(
-            onPressed: () => onPick(r),
-            child: Text(r.displayName, textAlign: TextAlign.center),
+        ConstrainedBox(
+          constraints: BoxConstraints(
+            maxHeight: MediaQuery.sizeOf(context).height *
+                onboardingPickListMaxHeightFraction,
+          ),
+          child: ListView(
+            shrinkWrap: true,
+            children: candidates
+                .map(
+                  (GeocodingResult r) => Padding(
+                    padding: const EdgeInsets.only(bottom: onboardingItemGap),
+                    child: OutlinedButton(
+                      onPressed: () => onPick(r),
+                      child: Text(r.displayName, textAlign: TextAlign.center),
+                    ),
+                  ),
+                )
+                .toList(),
           ),
         ),
         Text(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -53,6 +53,9 @@ enum _Phase {
 
   /// Geocoding the manual-entry string.
   geocoding,
+
+  /// Multiple geocoding results returned; user must pick one.
+  picking,
 }
 
 // ---------------------------------------------------------------------------
@@ -81,6 +84,7 @@ class _LocationOnboardingScreenState
   _Phase _phase = _Phase.idle;
   bool _continuing = false;
   _ConfirmResult? _pending;
+  List<GeocodingResult> _candidates = <GeocodingResult>[];
   String _errorMessage = '';
 
   final TextEditingController _manualController = TextEditingController();
@@ -179,17 +183,24 @@ class _LocationOnboardingScreenState
     });
 
     try {
-      final GeocodingResult result = await _geocodingApi(
+      final List<GeocodingResult> results = await _geocodingApi(
         proxyBaseUrl,
         deviceId,
-      ).geocode(query);
+      ).geocodeMultiple(query);
 
       if (!mounted) return;
 
-      setState(() {
-        _pending = (result: result, fromGps: false);
-        _phase = _Phase.confirm;
-      });
+      if (results.length == 1) {
+        setState(() {
+          _pending = (result: results.first, fromGps: false);
+          _phase = _Phase.confirm;
+        });
+      } else {
+        setState(() {
+          _candidates = results;
+          _phase = _Phase.picking;
+        });
+      }
     } on GeocodingNotFoundException {
       if (!mounted) return;
       setState(() {
@@ -206,6 +217,14 @@ class _LocationOnboardingScreenState
         _errorMessage = 'Something went wrong. Please try again.';
       });
     }
+  }
+
+  void _onPickCandidate(GeocodingResult result) {
+    setState(() {
+      _candidates = <GeocodingResult>[];
+      _pending = (result: result, fromGps: false);
+      _phase = _Phase.confirm;
+    });
   }
 
   // -------------------------------------------------------------------------
@@ -318,6 +337,12 @@ class _LocationOnboardingScreenState
                   focusNode: _manualFocus,
                   loading: _phase == _Phase.geocoding,
                   onSearch: onManualSearch,
+                ),
+
+              if (_phase == _Phase.picking)
+                _PickList(
+                  candidates: _candidates,
+                  onPick: _onPickCandidate,
                 ),
 
               if (_phase == _Phase.confirm)
@@ -520,6 +545,33 @@ class _ConfirmCard extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+}
+
+class _PickList extends StatelessWidget {
+  const _PickList({required this.candidates, required this.onPick});
+
+  final List<GeocodingResult> candidates;
+  final void Function(GeocodingResult) onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      spacing: onboardingItemGap,
+      children: <Widget>[
+        Text(
+          'Select your location:',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        ...candidates.map(
+          (GeocodingResult r) => OutlinedButton(
+            onPressed: () => onPick(r),
+            child: Text(r.displayName, textAlign: TextAlign.center),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -153,9 +153,7 @@ class _LocationOnboardingScreenState
       );
     } on GeocodingNotFoundException {
       if (!mounted) return;
-      _setError(
-        'Could not determine your city. Try entering it manually.',
-      );
+      _setError('Could not determine your city. Try entering it manually.');
     } on Object {
       if (!mounted) return;
       _setError('Something went wrong. Please try again.');
@@ -594,10 +592,7 @@ class _PickList extends StatelessWidget {
           ),
           textAlign: TextAlign.center,
         ),
-        TextButton(
-          onPressed: onSearchAgain,
-          child: const Text('Search again'),
-        ),
+        TextButton(onPressed: onSearchAgain, child: const Text('Search again')),
       ],
     );
   }

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:uvalert/api/geocoding_api.dart';
@@ -140,6 +141,12 @@ class _LocationOnboardingScreenState
       // Permission denied; fall through to manual entry.
       setState(() => _phase = _Phase.manual);
       _manualFocus.requestFocus();
+    } on TimeoutException {
+      if (!mounted) return;
+      _setError(
+        'GPS is not available on this device. '
+        'Try entering your location manually.',
+      );
     } on GeocodingNotFoundException {
       if (!mounted) return;
       _setError('Could not determine your city. Try entering it manually.');

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -10,9 +10,8 @@ import 'package:uvalert/providers/location_provider.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
-import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
-import 'package:uvalert/storage/preferences.dart';
 
 // ---------------------------------------------------------------------------
 // Layout constants
@@ -231,20 +230,13 @@ class _LocationOnboardingScreenState
 
       if (!mounted) return;
 
-      final Preferences prefs = await ref.read(preferencesProvider.future);
-      // Mark onboarding complete only after all data is written; this is the
-      // last onboarding step until the notifications screen (issue #15) is
-      // added, at which point setFirstLaunchDone() moves there.
-      await prefs.setFirstLaunchDone();
-
-      if (!mounted) return;
-
       ref.invalidate(preferencesProvider);
 
-      // TODO(onboarding): navigate to notifications screen (issue #15).
       unawaited(
         Navigator.of(context).pushReplacement(
-          MaterialPageRoute<void>(builder: (_) => const DashboardScreen()),
+          MaterialPageRoute<void>(
+            builder: (_) => const NotificationOnboardingScreen(),
+          ),
         ),
       );
     } on Object {

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -153,7 +153,9 @@ class _LocationOnboardingScreenState
       );
     } on GeocodingNotFoundException {
       if (!mounted) return;
-      _setError('Could not determine your city. Try entering it manually.');
+      _setError(
+        'Could not determine your city. Try entering it manually.',
+      );
     } on Object {
       if (!mounted) return;
       _setError('Something went wrong. Please try again.');
@@ -206,9 +208,8 @@ class _LocationOnboardingScreenState
       setState(() {
         _phase = _Phase.manual;
         _errorMessage =
-            'Location not found. Try city only'
-            ' (e.g. "London") or with full country name'
-            ' (e.g. "London, England").';
+            'Location not found. Try adding region and country'
+            ' (e.g. "Washington, DC, US" or "London, England, GB").';
       });
     } on Object {
       if (!mounted) return;
@@ -225,6 +226,14 @@ class _LocationOnboardingScreenState
       _pending = (result: result, fromGps: false);
       _phase = _Phase.confirm;
     });
+  }
+
+  void _onSearchAgain() {
+    setState(() {
+      _candidates = <GeocodingResult>[];
+      _phase = _Phase.manual;
+    });
+    _manualFocus.requestFocus();
   }
 
   // -------------------------------------------------------------------------
@@ -343,6 +352,7 @@ class _LocationOnboardingScreenState
                 _PickList(
                   candidates: _candidates,
                   onPick: _onPickCandidate,
+                  onSearchAgain: _onSearchAgain,
                 ),
 
               if (_phase == _Phase.confirm)
@@ -465,7 +475,7 @@ class _ManualEntryField extends StatelessWidget {
       textInputAction: TextInputAction.search,
       onSubmitted: onSearch == null ? null : (_) => onSearch!(),
       decoration: InputDecoration(
-        hintText: 'City, State (e.g. New York, NY)',
+        hintText: 'City, Region, Country (e.g. Washington, DC, US)',
         border: const OutlineInputBorder(),
         suffixIcon: loading
             ? const Padding(
@@ -550,10 +560,15 @@ class _ConfirmCard extends StatelessWidget {
 }
 
 class _PickList extends StatelessWidget {
-  const _PickList({required this.candidates, required this.onPick});
+  const _PickList({
+    required this.candidates,
+    required this.onPick,
+    required this.onSearchAgain,
+  });
 
   final List<GeocodingResult> candidates;
   final void Function(GeocodingResult) onPick;
+  final VoidCallback onSearchAgain;
 
   @override
   Widget build(BuildContext context) {
@@ -570,6 +585,18 @@ class _PickList extends StatelessWidget {
             onPressed: () => onPick(r),
             child: Text(r.displayName, textAlign: TextAlign.center),
           ),
+        ),
+        Text(
+          'Not your city? Try adding region and country'
+          ' (e.g. "Washington, DC, US" or "London, England, GB").',
+          style: Theme.of(context).textTheme.bodySmall?.copyWith(
+            color: Theme.of(context).colorScheme.onSurfaceVariant,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        TextButton(
+          onPressed: onSearchAgain,
+          child: const Text('Search again'),
         ),
       ],
     );

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -97,14 +97,14 @@ class _NotificationOnboardingScreenState
                 label: 'Default Notifications',
                 description:
                     'Enable 4 threshold alert notifications for UV changes.',
-                onPressed: () => _onPressed(true),
+                onPressed: _continuing ? null : () => _onPressed(true),
               ),
 
               _OptionButton(
                 icon: Icons.notifications_off,
                 label: 'No Notifications',
                 description: 'Skip notifications for now.',
-                onPressed: () => _onPressed(false),
+                onPressed: _continuing ? null : () => _onPressed(false),
               ),
 
               const _Note(),
@@ -168,6 +168,7 @@ class _OptionButton extends StatelessWidget {
 
     return Semantics(
       button: true,
+      enabled: onPressed != null,
       label: label,
       hint: description,
       child: InkWell(

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -20,9 +20,10 @@ const int _notificationScreenIndex = totalOnboardingSteps - 1;
 
 /// Screen 3 of onboarding: lets the user choose notification preferences.
 ///
-/// Scaffold only -- choice UI and OS permission prompt are out of scope for
-/// this issue. Both options ("Default" and "None") advance to DashboardScreen.
-/// This screen owns the `setFirstLaunchDone()` call; it was moved here from
+/// Presents two options ("Default Notifications" and "No Notifications");
+/// the chosen value is persisted via `setNotificationsEnabled()` before
+/// advancing to [DashboardScreen]. This screen also owns the
+/// `setFirstLaunchDone()` call, which was moved here from
 /// `LocationOnboardingScreen` when this screen was inserted as the last
 /// onboarding step.
 class NotificationOnboardingScreen extends ConsumerStatefulWidget {
@@ -163,48 +164,53 @@ class _OptionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colors = theme.colorScheme;
-    return InkWell(
-      onTap: onPressed,
-      borderRadius: onboardingCardRadius,
-      child: Container(
-        width: double.infinity,
-        padding: const EdgeInsets.symmetric(
-          horizontal: onboardingCardPaddingHorizontal,
-          vertical: onboardingCardPaddingVertical,
-        ),
-        decoration: BoxDecoration(
-          borderRadius: onboardingCardRadius,
-          border: Border.all(
-            color: colors.outlineVariant,
-            width: onboardingSelectedBorderWidth,
+    return Semantics(
+      button: true,
+      label: label,
+      hint: description,
+      child: InkWell(
+        onTap: onPressed,
+        borderRadius: onboardingCardRadius,
+        child: Container(
+          width: double.infinity,
+          padding: const EdgeInsets.symmetric(
+            horizontal: onboardingCardPaddingHorizontal,
+            vertical: onboardingCardPaddingVertical,
           ),
-          color: colors.surface,
-        ),
-        child: Row(
-          children: <Widget>[
-            Icon(icon, color: colors.primary),
-            const SizedBox(width: onboardingItemGap),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                spacing: onboardingLabelGap,
-                children: <Widget>[
-                  Text(
-                    label,
-                    style: theme.textTheme.bodyLarge?.copyWith(
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Text(
-                    description,
-                    style: theme.textTheme.bodySmall?.copyWith(
-                      color: colors.onSurfaceVariant,
-                    ),
-                  ),
-                ],
-              ),
+          decoration: BoxDecoration(
+            borderRadius: onboardingCardRadius,
+            border: Border.all(
+              color: colors.outlineVariant,
+              width: onboardingSelectedBorderWidth,
             ),
-          ],
+            color: colors.surface,
+          ),
+          child: Row(
+            children: <Widget>[
+              Icon(icon, color: colors.primary),
+              const SizedBox(width: onboardingItemGap),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  spacing: onboardingLabelGap,
+                  children: <Widget>[
+                    Text(
+                      label,
+                      style: theme.textTheme.bodyLarge?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text(
+                      description,
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: colors.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -133,6 +133,7 @@ class _Header extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+
     return Column(
       spacing: onboardingItemGap,
       children: <Widget>[
@@ -164,6 +165,7 @@ class _OptionButton extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colors = theme.colorScheme;
+
     return Semantics(
       button: true,
       label: label,
@@ -223,6 +225,7 @@ class _Note extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
+
     return Text(
       'More notification options can be found in Settings on the Dashboard.',
       textAlign: TextAlign.center,

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -1,0 +1,228 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uvalert/constants.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/providers/settings_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/onboarding_progress_dots.dart';
+import 'package:uvalert/storage/preferences.dart';
+
+// ---------------------------------------------------------------------------
+// Layout constants
+// ---------------------------------------------------------------------------
+const int _notificationScreenIndex = totalOnboardingSteps - 1;
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+/// Screen 3 of onboarding: lets the user choose notification preferences.
+///
+/// Scaffold only -- choice UI and OS permission prompt are out of scope for
+/// this issue. Both options ("Default" and "None") advance to DashboardScreen.
+/// This screen owns the `setFirstLaunchDone()` call; it was moved here from
+/// `LocationOnboardingScreen` when this screen was inserted as the last
+/// onboarding step.
+class NotificationOnboardingScreen extends ConsumerStatefulWidget {
+  /// Creates a [NotificationOnboardingScreen].
+  const NotificationOnboardingScreen({super.key});
+
+  @override
+  ConsumerState<NotificationOnboardingScreen> createState() =>
+      _NotificationOnboardingScreenState();
+}
+
+class _NotificationOnboardingScreenState
+    extends ConsumerState<NotificationOnboardingScreen> {
+  bool _continuing = false;
+
+  void _onPressed(bool notificationsEnabled) {
+    if (_continuing) return;
+    unawaited(_advance(notificationsEnabled: notificationsEnabled));
+  }
+
+  Future<void> _advance({required bool notificationsEnabled}) async {
+    setState(() => _continuing = true);
+
+    try {
+      await ref
+          .read(settingsProvider.notifier)
+          .setNotificationsEnabled(value: notificationsEnabled);
+
+      final Preferences prefs = await ref.read(preferencesProvider.future);
+
+      await prefs.setFirstLaunchDone();
+
+      if (!mounted) return;
+
+      unawaited(
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(builder: (_) => const DashboardScreen()),
+        ),
+      );
+    } on Object {
+      if (!mounted) return;
+
+      setState(() => _continuing = false);
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text('Something went wrong. Please try again.'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(
+            horizontal: onboardingPaddingHorizontal,
+            vertical: onboardingPaddingVertical,
+          ),
+          child: Column(
+            spacing: onboardingSectionGap,
+            children: <Widget>[
+              const Spacer(),
+
+              const _Header(),
+
+              _OptionButton(
+                icon: Icons.notifications_active,
+                label: 'Default Notifications',
+                description:
+                    'Enable 4 threshold alert notifications for UV changes.',
+                onPressed: () => _onPressed(true),
+              ),
+
+              _OptionButton(
+                icon: Icons.notifications_off,
+                label: 'No Notifications',
+                description: 'Skip notifications for now.',
+                onPressed: () => _onPressed(false),
+              ),
+
+              const _Note(),
+
+              const Spacer(),
+
+              const OnboardingProgressDots(
+                current: _notificationScreenIndex,
+                total: totalOnboardingSteps,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Sub-widgets (private)
+// ---------------------------------------------------------------------------
+
+class _Header extends StatelessWidget {
+  const _Header();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Column(
+      spacing: onboardingItemGap,
+      children: <Widget>[
+        Text('Notifications', style: theme.textTheme.headlineMedium),
+        Text(
+          'Would you like UV Alert to notify you when UV levels change?',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium,
+        ),
+      ],
+    );
+  }
+}
+
+class _OptionButton extends StatelessWidget {
+  const _OptionButton({
+    required this.icon,
+    required this.label,
+    required this.description,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final String description;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+    return InkWell(
+      onTap: onPressed,
+      borderRadius: onboardingCardRadius,
+      child: Container(
+        width: double.infinity,
+        padding: const EdgeInsets.symmetric(
+          horizontal: onboardingCardPaddingHorizontal,
+          vertical: onboardingCardPaddingVertical,
+        ),
+        decoration: BoxDecoration(
+          borderRadius: onboardingCardRadius,
+          border: Border.all(
+            color: colors.outlineVariant,
+            width: onboardingSelectedBorderWidth,
+          ),
+          color: colors.surface,
+        ),
+        child: Row(
+          children: <Widget>[
+            Icon(icon, color: colors.primary),
+            const SizedBox(width: onboardingItemGap),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                spacing: onboardingLabelGap,
+                children: <Widget>[
+                  Text(
+                    label,
+                    style: theme.textTheme.bodyLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    description,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: colors.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Note extends StatelessWidget {
+  const _Note();
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Text(
+      'More notification options can be found in Settings on the Dashboard.',
+      textAlign: TextAlign.center,
+      style: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.onSurfaceVariant,
+      ),
+    );
+  }
+}

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -7,6 +7,7 @@ import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/location_onboarding_screen.dart';
+import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
@@ -36,6 +37,7 @@ enum _SplashStep {
 /// Returns the first screen the user should see based on [prefs].
 Widget _onboardingDestination(Preferences prefs) {
   if (!prefs.isFirstLaunch) return const DashboardScreen();
+  if (prefs.isLocationStepDone) return const NotificationOnboardingScreen();
   if (prefs.isThemeStepDone) return const LocationOnboardingScreen();
   return const ThemeOnboardingScreen();
 }

--- a/lib/screens/theme_onboarding_screen.dart
+++ b/lib/screens/theme_onboarding_screen.dart
@@ -17,9 +17,6 @@ const Duration _cardAnimationDuration = Duration(milliseconds: 200);
 
 const double _unselectedBorderWidth = 1;
 
-const BorderRadius _cardRadius = BorderRadius.all(
-  Radius.circular(onboardingCardBorderRadius),
-);
 
 const double _cardIconGap = 16;
 
@@ -175,7 +172,7 @@ class _ThemeCard extends StatelessWidget {
       label: label,
       child: InkWell(
         onTap: onTap,
-        borderRadius: _cardRadius,
+        borderRadius: onboardingCardRadius,
 
         child: AnimatedContainer(
           duration: _cardAnimationDuration,
@@ -185,7 +182,7 @@ class _ThemeCard extends StatelessWidget {
           ),
 
           decoration: BoxDecoration(
-            borderRadius: _cardRadius,
+            borderRadius: onboardingCardRadius,
 
             border: Border.all(
               color: selected ? colors.primary : colors.outlineVariant,

--- a/lib/screens/theme_onboarding_screen.dart
+++ b/lib/screens/theme_onboarding_screen.dart
@@ -17,7 +17,6 @@ const Duration _cardAnimationDuration = Duration(milliseconds: 200);
 
 const double _unselectedBorderWidth = 1;
 
-
 const double _cardIconGap = 16;
 
 // (label, icon, themeMode) for each selectable theme option.

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -52,19 +52,21 @@ class Preferences {
       _prefs.setBool(_keyFirstLaunch, false);
 
   /// Whether the theme onboarding step has been completed.
-  bool get isThemeStepDone => _prefs.getBool(_keyThemeStepDone) ?? false;
+  bool get isThemeStepDone => _isStepDone(_keyThemeStepDone);
 
   /// Marks the theme onboarding step as complete.
-  Future<void> setThemeStepDone() async =>
-      _prefs.setBool(_keyThemeStepDone, true);
+  Future<void> setThemeStepDone() async => _setStepDone(_keyThemeStepDone);
 
   /// Whether the location onboarding step has been completed.
-  bool get isLocationStepDone =>
-      _prefs.getBool(_keyLocationStepDone) ?? false;
+  bool get isLocationStepDone => _isStepDone(_keyLocationStepDone);
 
   /// Marks the location onboarding step as complete.
   Future<void> setLocationStepDone() async =>
-      _prefs.setBool(_keyLocationStepDone, true);
+      _setStepDone(_keyLocationStepDone);
+
+  bool _isStepDone(String key) => _prefs.getBool(key) ?? false;
+
+  Future<void> _setStepDone(String key) async => _prefs.setBool(key, true);
 
   /// The stored device UUID, or `null` if not yet set.
   String? get uuid => _prefs.getString(_keyUuid);

--- a/lib/storage/preferences.dart
+++ b/lib/storage/preferences.dart
@@ -20,6 +20,13 @@ class Preferences {
   @visibleForTesting
   static const String keyThemeStepDoneForTesting = _keyThemeStepDone;
 
+  static const String _keyLocationStepDone = '${_prefix}location_step_done';
+
+  /// The SharedPreferences key for [isLocationStepDone].
+  /// Exposed for tests only.
+  @visibleForTesting
+  static const String keyLocationStepDoneForTesting = _keyLocationStepDone;
+
   static const String _keyUuid = '${_prefix}uuid';
   static const String _keyTheme = '${_prefix}theme';
   static const String _keyUseGps = '${_prefix}use_gps';
@@ -50,6 +57,14 @@ class Preferences {
   /// Marks the theme onboarding step as complete.
   Future<void> setThemeStepDone() async =>
       _prefs.setBool(_keyThemeStepDone, true);
+
+  /// Whether the location onboarding step has been completed.
+  bool get isLocationStepDone =>
+      _prefs.getBool(_keyLocationStepDone) ?? false;
+
+  /// Marks the location onboarding step as complete.
+  Future<void> setLocationStepDone() async =>
+      _prefs.setBool(_keyLocationStepDone, true);
 
   /// The stored device UUID, or `null` if not yet set.
   String? get uuid => _prefs.getString(_keyUuid);

--- a/test/fakes/fake_geolocator.dart
+++ b/test/fakes/fake_geolocator.dart
@@ -9,9 +9,9 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
   LocationPermission checkResult = LocationPermission.always;
   LocationPermission requestResult = LocationPermission.always;
   Position? positionResult;
-  // When set, getCurrentPosition waits this long before resolving. In widget
-  // tests (fakeAsync), this lets timeout tests trigger TimeoutException by
-  // advancing simulated time via `tester.pump(...)`.
+  // When set, getCurrentPosition waits this long before resolving.
+  // In testWidgets (fakeAsync), advance simulated time with tester.pump(...) to
+  // avoid real wall-clock delay. In plain test() calls the delay is real time.
   Duration? positionDelay;
 
   @override

--- a/test/fakes/fake_geolocator.dart
+++ b/test/fakes/fake_geolocator.dart
@@ -9,6 +9,9 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
   LocationPermission checkResult = LocationPermission.always;
   LocationPermission requestResult = LocationPermission.always;
   Position? positionResult;
+  // When set, getCurrentPosition waits this long before resolving, allowing
+  // timeout tests to trigger TimeoutException without real wall-clock delay.
+  Duration? positionDelay;
 
   @override
   Future<LocationPermission> checkPermission() async => checkResult;
@@ -20,6 +23,9 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
   Future<Position> getCurrentPosition({
     LocationSettings? locationSettings,
   }) async {
+    if (positionDelay != null) {
+      await Future<void>.delayed(positionDelay!);
+    }
     if (positionResult == null) {
       throw StateError(
         'FakeGeolocatorPlatform: positionResult not set for this test',

--- a/test/fakes/fake_geolocator.dart
+++ b/test/fakes/fake_geolocator.dart
@@ -9,8 +9,9 @@ class FakeGeolocatorPlatform extends GeolocatorPlatform {
   LocationPermission checkResult = LocationPermission.always;
   LocationPermission requestResult = LocationPermission.always;
   Position? positionResult;
-  // When set, getCurrentPosition waits this long before resolving, allowing
-  // timeout tests to trigger TimeoutException without real wall-clock delay.
+  // When set, getCurrentPosition waits this long before resolving. In widget
+  // tests (fakeAsync), this lets timeout tests trigger TimeoutException by
+  // advancing simulated time via `tester.pump(...)`.
   Duration? positionDelay;
 
   @override

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -16,42 +16,70 @@ GeocodingApi _makeApi(http.Client client) => GeocodingApi(
   httpClient: client,
 );
 
-// Proxy response shape: { lat, lon, name, country, state? }
+// Proxy response shape: array of { lat, lon, name, country, state? }
 const String _validBodyWithState =
+    '[{"lat":36.75,"lon":-119.65,'
+    '"name":"Fresno","country":"US","state":"California"}]';
+
+const String _validBodyNoState =
+    '[{"lat":48.85,"lon":2.35,"name":"Paris","country":"FR"}]';
+
+const String _validBodyMultiple =
+    '[{"lat":51.5,"lon":-0.1,"name":"London",'
+    '"country":"GB","state":"England"},'
+    '{"lat":42.9,"lon":-81.2,"name":"London",'
+    '"country":"CA","state":"Ontario"}]';
+
+// reverseGeocode uses a single-object response (separate OWM endpoint).
+const String _reverseBodyWithState =
     '{"lat":36.75,"lon":-119.65,'
     '"name":"Fresno","country":"US","state":"California"}';
 
-const String _validBodyNoState =
-    '{"lat":48.85,"lon":2.35,"name":"Paris","country":"FR"}';
-
 // ---------------------------------------------------------------------------
-// geocode
+// geocodeMultiple
 // ---------------------------------------------------------------------------
 
 void main() {
-  group('GeocodingApi.geocode', () {
-    test('returns result on 200 with state field', () async {
+  group('GeocodingApi.geocodeMultiple', () {
+    test('returns single result on 200 with state field', () async {
       final GeocodingApi api = _makeApi(
         mockClientReturning(200, _validBodyWithState),
       );
       addTearDown(api.dispose);
-      final GeocodingResult result = await api.geocode('Fresno, CA');
+      final List<GeocodingResult> results =
+          await api.geocodeMultiple('Fresno, CA');
 
-      expect(result.lat, 36.75);
-      expect(result.lon, -119.65);
-      expect(result.displayName, 'Fresno, California, US');
+      expect(results, hasLength(1));
+      expect(results.first.lat, 36.75);
+      expect(results.first.lon, -119.65);
+      expect(results.first.displayName, 'Fresno, California, US');
     });
 
-    test('returns result on 200 without state field', () async {
+    test('returns single result on 200 without state field', () async {
       final GeocodingApi api = _makeApi(
         mockClientReturning(200, _validBodyNoState),
       );
       addTearDown(api.dispose);
-      final GeocodingResult result = await api.geocode('Paris');
+      final List<GeocodingResult> results = await api.geocodeMultiple('Paris');
 
-      expect(result.lat, 48.85);
-      expect(result.lon, 2.35);
-      expect(result.displayName, 'Paris, FR');
+      expect(results, hasLength(1));
+      expect(results.first.lat, 48.85);
+      expect(results.first.lon, 2.35);
+      expect(results.first.displayName, 'Paris, FR');
+    });
+
+    test('returns multiple results when proxy returns several matches',
+        () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(200, _validBodyMultiple),
+      );
+      addTearDown(api.dispose);
+      final List<GeocodingResult> results =
+          await api.geocodeMultiple('London');
+
+      expect(results, hasLength(2));
+      expect(results[0].displayName, 'London, England, GB');
+      expect(results[1].displayName, 'London, Ontario, CA');
     });
 
     test('throws GeocodingNotFoundException on 404', () async {
@@ -59,7 +87,7 @@ void main() {
       addTearDown(api.dispose);
 
       await expectLater(
-        api.geocode('nowhere'),
+        api.geocodeMultiple('nowhere'),
         throwsA(isA<GeocodingNotFoundException>()),
       );
     });
@@ -69,42 +97,37 @@ void main() {
       addTearDown(api.dispose);
 
       await expectLater(
-        api.geocode('Fresno, CA'),
+        api.geocodeMultiple('Fresno, CA'),
         throwsA(isA<GeocodingException>()),
       );
     });
 
-    test('throws GeocodingException when body is not a JSON object', () async {
+    test('throws GeocodingException when body is not a JSON array', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(200, '"string"'));
       addTearDown(api.dispose);
 
       await expectLater(
-        api.geocode('Fresno, CA'),
+        api.geocodeMultiple('Fresno, CA'),
         throwsA(isA<GeocodingException>()),
       );
     });
 
-    test(
-      'throws GeocodingException when required fields are missing',
-      () async {
-        final GeocodingApi api = _makeApi(
-          mockClientReturning(200, '{"lat":36.75}'),
-        );
-        addTearDown(api.dispose);
+    test('throws GeocodingException when array is empty', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(200, '[]'));
+      addTearDown(api.dispose);
 
-        await expectLater(
-          api.geocode('Fresno, CA'),
-          throwsA(isA<GeocodingException>()),
-        );
-      },
-    );
+      await expectLater(
+        api.geocodeMultiple('Fresno, CA'),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
 
     test('throws GeocodingException on malformed JSON body', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(200, '{not json}'));
       addTearDown(api.dispose);
 
       await expectLater(
-        api.geocode('Fresno, CA'),
+        api.geocodeMultiple('Fresno, CA'),
         throwsA(isA<GeocodingException>()),
       );
     });
@@ -118,7 +141,7 @@ void main() {
 
       final GeocodingApi api = _makeApi(client);
       addTearDown(api.dispose);
-      await api.geocode('Fresno, CA');
+      await api.geocodeMultiple('Fresno, CA');
 
       expect(captured?.queryParameters['q'], 'Fresno, CA');
     });
@@ -132,7 +155,7 @@ void main() {
 
       final GeocodingApi api = _makeApi(client);
       addTearDown(api.dispose);
-      await api.geocode('Fresno, CA');
+      await api.geocodeMultiple('Fresno, CA');
 
       expect(capturedHeaders?[deviceIdHeader], 'test-device-id');
     });
@@ -150,7 +173,7 @@ void main() {
         httpClient: client,
       );
       addTearDown(api.dispose);
-      await api.geocode('Fresno, CA');
+      await api.geocodeMultiple('Fresno, CA');
 
       expect(captured?.host, 'proxy.test');
       expect(captured?.path, '/api/geocode');
@@ -164,7 +187,7 @@ void main() {
   group('GeocodingApi.reverseGeocode', () {
     test('returns result on 200 with state field', () async {
       final GeocodingApi api = _makeApi(
-        mockClientReturning(200, _validBodyWithState),
+        mockClientReturning(200, _reverseBodyWithState),
       );
       addTearDown(api.dispose);
       final GeocodingResult result = await api.reverseGeocode(
@@ -191,7 +214,7 @@ void main() {
       Uri? captured;
       final MockClient client = MockClient((http.Request req) async {
         captured = req.url;
-        return http.Response(_validBodyWithState, 200);
+        return http.Response(_reverseBodyWithState, 200);
       });
 
       final GeocodingApi api = _makeApi(client);
@@ -207,7 +230,7 @@ void main() {
       Map<String, String>? capturedHeaders;
       final MockClient client = MockClient((http.Request req) async {
         capturedHeaders = req.headers;
-        return http.Response(_validBodyWithState, 200);
+        return http.Response(_reverseBodyWithState, 200);
       });
 
       final GeocodingApi api = _makeApi(client);

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -46,8 +46,9 @@ void main() {
         mockClientReturning(200, _validBodyWithState),
       );
       addTearDown(api.dispose);
-      final List<GeocodingResult> results =
-          await api.geocodeMultiple('Fresno, CA');
+      final List<GeocodingResult> results = await api.geocodeMultiple(
+        'Fresno, CA',
+      );
 
       expect(results, hasLength(1));
       expect(results.first.lat, 36.75);
@@ -68,19 +69,22 @@ void main() {
       expect(results.first.displayName, 'Paris, FR');
     });
 
-    test('returns multiple results when proxy returns several matches',
-        () async {
-      final GeocodingApi api = _makeApi(
-        mockClientReturning(200, _validBodyMultiple),
-      );
-      addTearDown(api.dispose);
-      final List<GeocodingResult> results =
-          await api.geocodeMultiple('London');
+    test(
+      'returns multiple results when proxy returns several matches',
+      () async {
+        final GeocodingApi api = _makeApi(
+          mockClientReturning(200, _validBodyMultiple),
+        );
+        addTearDown(api.dispose);
+        final List<GeocodingResult> results = await api.geocodeMultiple(
+          'London',
+        );
 
-      expect(results, hasLength(2));
-      expect(results[0].displayName, 'London, England, GB');
-      expect(results[1].displayName, 'London, Ontario, CA');
-    });
+        expect(results, hasLength(2));
+        expect(results[0].displayName, 'London, England, GB');
+        expect(results[1].displayName, 'London, Ontario, CA');
+      },
+    );
 
     test('throws GeocodingNotFoundException on 404', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(404, 'not found'));

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -116,13 +116,13 @@ void main() {
       );
     });
 
-    test('throws GeocodingException when array is empty', () async {
+    test('throws GeocodingNotFoundException when array is empty', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(200, '[]'));
       addTearDown(api.dispose);
 
       await expectLater(
         api.geocodeMultiple('Fresno, CA'),
-        throwsA(isA<GeocodingException>()),
+        throwsA(isA<GeocodingNotFoundException>()),
       );
     });
 

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -243,6 +243,41 @@ void main() {
 
       expect(capturedHeaders?[deviceIdHeader], 'test-device-id');
     });
+
+    test('throws GeocodingException when body is not a JSON object', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(200, '"string"'));
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.reverseGeocode(lat: 36.75, lon: -119.65),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
+
+    test('throws GeocodingException when required fields are missing',
+        () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(200, '{"lat":36.75,"lon":-119.65}'),
+      );
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.reverseGeocode(lat: 36.75, lon: -119.65),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
+
+    test('throws GeocodingException on malformed JSON body', () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(200, '{not json}'),
+      );
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.reverseGeocode(lat: 36.75, lon: -119.65),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:uvalert/constants.dart';
 
 /// Returns a [MockClient] that responds with [status] and an optional [body].
 http.Client mockClientReturning(int status, [String body = '']) =>
@@ -8,6 +9,14 @@ http.Client mockClientReturning(int status, [String body = '']) =>
 
 // 100 ms past the 2-second minimum splash floor in OnboardingScreen.
 const Duration _splashClearDelay = Duration(milliseconds: 2100);
+
+/// How far past [gpsTimeout] the fake GPS delay is set so the timeout fires.
+// ignore: avoid_unused_field — used in test files that import helpers.dart
+const Duration gpsOvershoot = Duration(milliseconds: 100);
+
+/// Extra buffer added to [gpsTimeout] for the per-test [Timeout] annotation.
+// ignore: avoid_unused_field — used in test files that import helpers.dart
+const Duration gpsTestBuffer = Duration(seconds: 5);
 
 /// Pumps the splash screen and settles all resulting navigation animations.
 ///

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -11,11 +11,9 @@ http.Client mockClientReturning(int status, [String body = '']) =>
 const Duration _splashClearDelay = Duration(milliseconds: 2100);
 
 /// How far past [gpsTimeout] the fake GPS delay is set so the timeout fires.
-// ignore: avoid_unused_field — used in test files that import helpers.dart
 const Duration gpsOvershoot = Duration(milliseconds: 100);
 
 /// Extra buffer added to [gpsTimeout] for the per-test [Timeout] annotation.
-// ignore: avoid_unused_field — used in test files that import helpers.dart
 const Duration gpsTestBuffer = Duration(seconds: 5);
 
 /// Pumps the splash screen and settles all resulting navigation animations.

--- a/test/integration/geocoding_api_live_test.dart
+++ b/test/integration/geocoding_api_live_test.dart
@@ -30,8 +30,9 @@ void main() {
     test(
       'happy path with state - Fresno returns name, state, country',
       () async {
-        final List<GeocodingResult> results =
-            await api.geocodeMultiple('Fresno');
+        final List<GeocodingResult> results = await api.geocodeMultiple(
+          'Fresno',
+        );
 
         expect(results, isNotEmpty);
         final GeocodingResult first = results.first;
@@ -45,8 +46,9 @@ void main() {
     test(
       'international city - Tokyo returns valid coords and displayName',
       () async {
-        final List<GeocodingResult> results =
-            await api.geocodeMultiple('Tokyo, Japan');
+        final List<GeocodingResult> results = await api.geocodeMultiple(
+          'Tokyo, Japan',
+        );
 
         expect(results, isNotEmpty);
         final GeocodingResult first = results.first;
@@ -73,8 +75,9 @@ void main() {
     test(
       'coords round-trip - Fresno lat/lon are in the right ballpark',
       () async {
-        final List<GeocodingResult> results =
-            await api.geocodeMultiple('Fresno');
+        final List<GeocodingResult> results = await api.geocodeMultiple(
+          'Fresno',
+        );
 
         expect(results, isNotEmpty);
         final GeocodingResult first = results.first;

--- a/test/integration/geocoding_api_live_test.dart
+++ b/test/integration/geocoding_api_live_test.dart
@@ -30,29 +30,33 @@ void main() {
     test(
       'happy path with state - Fresno returns name, state, country',
       () async {
-        final GeocodingResult result = await api.geocode('Fresno');
+        final List<GeocodingResult> results =
+            await api.geocodeMultiple('Fresno');
 
-        expect(result.lat, isNonZero);
-        expect(result.lon, isNonZero);
-        // Proxy returns { name, state, country };
-        // displayName is built as "name, state, country"
-        expect(result.displayName, contains('Fresno'));
-        expect(result.displayName, contains('US'));
+        expect(results, isNotEmpty);
+        final GeocodingResult first = results.first;
+        expect(first.lat, isNonZero);
+        expect(first.lon, isNonZero);
+        expect(first.displayName, contains('Fresno'));
+        expect(first.displayName, contains('US'));
       },
     );
 
     test(
       'international city - Tokyo returns valid coords and displayName',
       () async {
-        final GeocodingResult result = await api.geocode('Tokyo, Japan');
+        final List<GeocodingResult> results =
+            await api.geocodeMultiple('Tokyo, Japan');
 
-        expect(result.lat, isNonZero);
-        expect(result.lon, isNonZero);
-        expect(result.displayName, isNotEmpty);
-        expect(result.displayName, contains('JP'));
+        expect(results, isNotEmpty);
+        final GeocodingResult first = results.first;
+        expect(first.lat, isNonZero);
+        expect(first.lon, isNonZero);
+        expect(first.displayName, isNotEmpty);
+        expect(first.displayName, contains('JP'));
         // Tokyo lat/lon ballpark: 35-36°N, 139-140°E
-        expect(result.lat, inInclusiveRange(34.0, 37.0));
-        expect(result.lon, inInclusiveRange(138.0, 141.0));
+        expect(first.lat, inInclusiveRange(34.0, 37.0));
+        expect(first.lon, inInclusiveRange(138.0, 141.0));
       },
     );
 
@@ -60,7 +64,7 @@ void main() {
       '404 path - nonsense query throws GeocodingNotFoundException',
       () async {
         await expectLater(
-          api.geocode('xyzzy_no_such_place_8675309'),
+          api.geocodeMultiple('xyzzy_no_such_place_8675309'),
           throwsA(isA<GeocodingNotFoundException>()),
         );
       },
@@ -69,11 +73,14 @@ void main() {
     test(
       'coords round-trip - Fresno lat/lon are in the right ballpark',
       () async {
-        final GeocodingResult result = await api.geocode('Fresno');
+        final List<GeocodingResult> results =
+            await api.geocodeMultiple('Fresno');
 
+        expect(results, isNotEmpty);
+        final GeocodingResult first = results.first;
         // Fresno, CA is roughly 36-37°N, 119-120°W
-        expect(result.lat, inInclusiveRange(35.0, 38.0));
-        expect(result.lon, inInclusiveRange(-121.0, -118.0));
+        expect(first.lat, inInclusiveRange(35.0, 38.0));
+        expect(first.lon, inInclusiveRange(-121.0, -118.0));
       },
     );
   });

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -391,7 +391,7 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
-  // Continue navigates to Dashboard
+  // Continue navigates to NotificationOnboardingScreen
   // -------------------------------------------------------------------------
 
   testWidgets(

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -487,31 +487,32 @@ void main() {
   // GPS timeout (TimeoutException branch in _onUseMyLocation)
   // -------------------------------------------------------------------------
 
-  testWidgets('GPS timeout shows not-available error message', (
-    WidgetTester tester,
-  ) async {
-    final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
-      ..checkResult = LocationPermission.always
-      ..positionDelay = gpsTimeout + gpsOvershoot
-      ..positionResult = fakePosition();
+  testWidgets(
+    'GPS timeout shows not-available error message',
+    (WidgetTester tester) async {
+      final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+        ..checkResult = LocationPermission.always
+        ..positionDelay = gpsTimeout + gpsOvershoot
+        ..positionResult = fakePosition();
 
-    await tester.pumpWidget(
-      _wrap(
-        LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi()),
-        platform: platform,
-      ),
-    );
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi()),
+          platform: platform,
+        ),
+      );
 
-    await tester.tap(find.text('Use My Location'));
-    await tester.pump(gpsTimeout + gpsOvershoot);
-    await tester.pumpAndSettle();
+      await tester.tap(find.text('Use My Location'));
+      await tester.pump(gpsTimeout + gpsOvershoot);
+      await tester.pumpAndSettle();
 
-    expect(
-      find.textContaining('GPS is not available on this device'),
-      findsOneWidget,
-    );
-  },
-  timeout: Timeout(gpsTimeout + gpsTestBuffer));
+      expect(
+        find.textContaining('GPS is not available on this device'),
+        findsOneWidget,
+      );
+    },
+    timeout: Timeout(gpsTimeout + gpsTestBuffer),
+  );
 
   // -------------------------------------------------------------------------
   // CircularProgressIndicator during loading (line 300)

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/api/geocoding_api.dart';
+import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/device_id_provider.dart';
 import 'package:uvalert/providers/location_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
@@ -490,7 +491,7 @@ void main() {
   ) async {
     final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
       ..checkResult = LocationPermission.always
-      ..positionDelay = const Duration(seconds: 11)
+      ..positionDelay = gpsTimeout + const Duration(milliseconds: 100)
       ..positionResult = fakePosition();
 
     await tester.pumpWidget(
@@ -501,7 +502,7 @@ void main() {
     );
 
     await tester.tap(find.text('Use My Location'));
-    await tester.pump(const Duration(seconds: 11));
+    await tester.pump(gpsTimeout + const Duration(milliseconds: 100));
     await tester.pumpAndSettle();
 
     expect(

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -18,9 +18,7 @@ import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 import 'fakes/fake_geolocator.dart';
-
-const Duration _gpsOvershoot = Duration(milliseconds: 100);
-const Duration _gpsTestBuffer = Duration(seconds: 5);
+import 'helpers.dart';
 
 // ---------------------------------------------------------------------------
 // LocationNotifier that succeeds without setting state (covers null-loc path)
@@ -494,7 +492,7 @@ void main() {
   ) async {
     final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
       ..checkResult = LocationPermission.always
-      ..positionDelay = gpsTimeout + _gpsOvershoot
+      ..positionDelay = gpsTimeout + gpsOvershoot
       ..positionResult = fakePosition();
 
     await tester.pumpWidget(
@@ -505,7 +503,7 @@ void main() {
     );
 
     await tester.tap(find.text('Use My Location'));
-    await tester.pump(gpsTimeout + _gpsOvershoot);
+    await tester.pump(gpsTimeout + gpsOvershoot);
     await tester.pumpAndSettle();
 
     expect(
@@ -513,7 +511,7 @@ void main() {
       findsOneWidget,
     );
   },
-  timeout: Timeout(gpsTimeout + _gpsTestBuffer));
+  timeout: Timeout(gpsTimeout + gpsTestBuffer));
 
   // -------------------------------------------------------------------------
   // CircularProgressIndicator during loading (line 300)

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -4,6 +4,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/api/geocoding_api.dart';
 import 'package:uvalert/providers/device_id_provider.dart';
@@ -15,7 +17,6 @@ import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 import 'fakes/fake_geolocator.dart';
-import 'helpers.dart';
 
 // ---------------------------------------------------------------------------
 // LocationNotifier that succeeds without setting state (covers null-loc path)
@@ -46,20 +47,38 @@ class _ThrowingSettingsNotifier extends SettingsNotifier {
 
 const String _proxyUrl = 'https://proxy.test';
 
-// _parseResult assembles displayName as 'name, state, country'.
+// displayName assembled as 'name, state, country'.
 const String _displayName = 'Fresno, California, US';
-const String _validGeoBody =
+
+// geocodeMultiple (forward, ?q=) returns a JSON array.
+const String _validForwardBody =
+    '[{"lat":36.75,"lon":-119.65,'
+    '"name":"Fresno","state":"California","country":"US"}]';
+
+// reverseGeocode (?lat=&lon=) returns a single JSON object.
+const String _validReverseBody =
     '{"lat":36.75,"lon":-119.65,'
     '"name":"Fresno","state":"California","country":"US"}';
 
-GeocodingApi _fakeGeocodingApi({
-  int status = 200,
-  String body = _validGeoBody,
-}) {
+// Routes to array body for forward (?q=) and object body for reverse (?lat=).
+http.Client _geoClient({int status = 200, String? forwardBody}) {
+  final String fwd = forwardBody ?? _validForwardBody;
+  return MockClient((http.Request req) async {
+    if (req.url.queryParameters.containsKey('q')) {
+      return http.Response(fwd, status);
+    }
+    return http.Response(
+      status == 200 ? _validReverseBody : '',
+      status,
+    );
+  });
+}
+
+GeocodingApi _fakeGeocodingApi({int status = 200, String? forwardBody}) {
   return GeocodingApi(
     proxyBaseUrl: _proxyUrl,
     deviceId: 'test-device-id',
-    httpClient: mockClientReturning(status, body),
+    httpClient: _geoClient(status: status, forwardBody: forwardBody),
   );
 }
 
@@ -215,7 +234,7 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 404, body: 'not found'),
+          geocodingApi: _fakeGeocodingApi(status: 404, forwardBody: '[]'),
         ),
       ),
     );
@@ -237,7 +256,7 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 500, body: 'error'),
+          geocodingApi: _fakeGeocodingApi(status: 500, forwardBody: 'error'),
         ),
       ),
     );
@@ -350,7 +369,7 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 404, body: 'not found'),
+          geocodingApi: _fakeGeocodingApi(status: 404, forwardBody: '[]'),
         ),
         platform: platform,
       ),

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -10,8 +10,8 @@ import 'package:uvalert/providers/device_id_provider.dart';
 import 'package:uvalert/providers/location_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
-import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/location_onboarding_screen.dart';
+import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 import 'fakes/fake_geolocator.dart';
@@ -369,25 +369,28 @@ void main() {
   // Continue navigates to Dashboard
   // -------------------------------------------------------------------------
 
-  testWidgets('tapping Continue after confirm navigates to DashboardScreen', (
+  testWidgets(
+    'tapping Continue after confirm navigates to NotificationOnboardingScreen',
+    (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
     );
     await _tapContinueAfterManualEntry(tester);
-    expect(find.byType(DashboardScreen), findsOneWidget);
+    expect(find.byType(NotificationOnboardingScreen), findsOneWidget);
   });
 
   testWidgets(
-    'tapping Continue after confirm persists isFirstLaunch as false',
+    'tapping Continue after confirm does not clear isFirstLaunch',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
       );
       await _tapContinueAfterManualEntry(tester);
       final Preferences prefs = await Preferences.load();
-      expect(prefs.isFirstLaunch, isFalse);
+      // setFirstLaunchDone() moved to NotificationOnboardingScreen (issue #15).
+      expect(prefs.isFirstLaunch, isTrue);
     },
   );
 
@@ -540,7 +543,7 @@ void main() {
       find.text('Something went wrong. Please try again.'),
       findsOneWidget,
     );
-    expect(find.byType(DashboardScreen), findsNothing);
+    expect(find.byType(NotificationOnboardingScreen), findsNothing);
   });
 
   testWidgets('_onConfirm error re-enables Continue button so user can retry', (

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -468,6 +468,35 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // GPS timeout (TimeoutException branch in _onUseMyLocation)
+  // -------------------------------------------------------------------------
+
+  testWidgets('GPS timeout shows not-available error message', (
+    WidgetTester tester,
+  ) async {
+    final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+      ..checkResult = LocationPermission.always
+      ..positionDelay = const Duration(seconds: 11)
+      ..positionResult = fakePosition();
+
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi()),
+        platform: platform,
+      ),
+    );
+
+    await tester.tap(find.text('Use My Location'));
+    await tester.pump(const Duration(seconds: 11));
+    await tester.pumpAndSettle();
+
+    expect(
+      find.textContaining('GPS is not available on this device'),
+      findsOneWidget,
+    );
+  });
+
+  // -------------------------------------------------------------------------
   // CircularProgressIndicator during loading (line 300)
   // -------------------------------------------------------------------------
 

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -62,6 +62,13 @@ const String _validReverseBody =
     '{"lat":36.75,"lon":-119.65,'
     '"name":"Fresno","state":"California","country":"US"}';
 
+// geocodeMultiple with two results (used by pick-list tests).
+const String _multiResultBody =
+    '[{"lat":51.5,"lon":-0.1,"name":"London",'
+    '"country":"GB","state":"England"},'
+    '{"lat":42.9,"lon":-81.2,"name":"London",'
+    '"country":"CA","state":"Ontario"}]';
+
 // Routes to array body for forward (?q=) and object body for reverse (?lat=).
 http.Client _geoClient({int status = 200, String? forwardBody}) {
   final String fwd = forwardBody ?? _validForwardBody;
@@ -69,7 +76,7 @@ http.Client _geoClient({int status = 200, String? forwardBody}) {
     if (req.url.queryParameters.containsKey('q')) {
       return http.Response(fwd, status);
     }
-    return http.Response(status == 200 ? _validReverseBody : '', status);
+    return http.Response(_validReverseBody, status);
   });
 }
 
@@ -632,16 +639,10 @@ void main() {
   testWidgets(
     'multiple geocode results shows pick list with all candidates',
     (WidgetTester tester) async {
-      const String multiBody =
-          '[{"lat":51.5,"lon":-0.1,"name":"London",'
-          '"country":"GB","state":"England"},'
-          '{"lat":42.9,"lon":-81.2,"name":"London",'
-          '"country":"CA","state":"Ontario"}]';
-
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
           ),
         ),
       );
@@ -661,16 +662,10 @@ void main() {
   testWidgets(
     'picking a candidate from pick list shows confirm card',
     (WidgetTester tester) async {
-      const String multiBody =
-          '[{"lat":51.5,"lon":-0.1,"name":"London",'
-          '"country":"GB","state":"England"},'
-          '{"lat":42.9,"lon":-81.2,"name":"London",'
-          '"country":"CA","state":"Ontario"}]';
-
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
           ),
         ),
       );
@@ -692,16 +687,10 @@ void main() {
   testWidgets(
     'tapping Search again from pick list returns to manual entry',
     (WidgetTester tester) async {
-      const String multiBody =
-          '[{"lat":51.5,"lon":-0.1,"name":"London",'
-          '"country":"GB","state":"England"},'
-          '{"lat":42.9,"lon":-81.2,"name":"London",'
-          '"country":"CA","state":"Ontario"}]';
-
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
           ),
         ),
       );

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -593,6 +593,135 @@ void main() {
     expect(find.byType(NotificationOnboardingScreen), findsNothing);
   });
 
+  // -------------------------------------------------------------------------
+  // GPS reverseGeocode timeout (inner TimeoutException, lines 144-145)
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'GPS reverseGeocode timeout shows city-not-determined error',
+    (WidgetTester tester) async {
+      final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+        ..checkResult = LocationPermission.always
+        ..positionResult = fakePosition(lat: 36.75, lon: -119.65);
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _ReverseTimeoutGeocodingApi(),
+          ),
+          platform: platform,
+        ),
+      );
+
+      await tester.tap(find.text('Use My Location'));
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'Could not determine your city. Try entering it manually.',
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Multiple geocoding results: _Phase.picking (lines 205-208, 358-362, 566+)
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'multiple geocode results shows pick list with all candidates',
+    (WidgetTester tester) async {
+      const String multiBody =
+          '[{"lat":51.5,"lon":-0.1,"name":"London",'
+          '"country":"GB","state":"England"},'
+          '{"lat":42.9,"lon":-81.2,"name":"London",'
+          '"country":"CA","state":"Ontario"}]';
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'London');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Select your location:'), findsOneWidget);
+      expect(find.text('London, England, GB'), findsOneWidget);
+      expect(find.text('London, Ontario, CA'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'picking a candidate from pick list shows confirm card',
+    (WidgetTester tester) async {
+      const String multiBody =
+          '[{"lat":51.5,"lon":-0.1,"name":"London",'
+          '"country":"GB","state":"England"},'
+          '{"lat":42.9,"lon":-81.2,"name":"London",'
+          '"country":"CA","state":"Ontario"}]';
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'London');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('London, England, GB'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('London, England, GB'), findsOneWidget);
+      expect(find.text('Select your location:'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'tapping Search again from pick list returns to manual entry',
+    (WidgetTester tester) async {
+      const String multiBody =
+          '[{"lat":51.5,"lon":-0.1,"name":"London",'
+          '"country":"GB","state":"England"},'
+          '{"lat":42.9,"lon":-81.2,"name":"London",'
+          '"country":"CA","state":"Ontario"}]';
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(forwardBody: multiBody),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+      await tester.enterText(find.byType(TextField), 'London');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Search again'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Select your location:'), findsNothing);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+
   testWidgets('_onConfirm error re-enables Continue button so user can retry', (
     WidgetTester tester,
   ) async {
@@ -632,4 +761,25 @@ class _SlowGeolocatorPlatform extends FakeGeolocatorPlatform {
   @override
   Future<Position> getCurrentPosition({LocationSettings? locationSettings}) =>
       _positionFuture;
+}
+
+// ---------------------------------------------------------------------------
+// GeocodingApi that times out only on reverseGeocode
+// ---------------------------------------------------------------------------
+
+class _ReverseTimeoutGeocodingApi extends GeocodingApi {
+  _ReverseTimeoutGeocodingApi()
+    : super(
+        proxyBaseUrl: _proxyUrl,
+        deviceId: 'test-device-id',
+      );
+
+  @override
+  Future<GeocodingResult> reverseGeocode({
+    required double lat,
+    required double lon,
+  }) =>
+      Future<GeocodingResult>.error(
+        TimeoutException('reverseGeocode timed out'),
+      );
 }

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -19,6 +19,9 @@ import 'package:uvalert/storage/preferences.dart';
 
 import 'fakes/fake_geolocator.dart';
 
+const Duration _gpsOvershoot = Duration(milliseconds: 100);
+const Duration _gpsTestBuffer = Duration(seconds: 5);
+
 // ---------------------------------------------------------------------------
 // LocationNotifier that succeeds without setting state (covers null-loc path)
 // ---------------------------------------------------------------------------
@@ -491,7 +494,7 @@ void main() {
   ) async {
     final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
       ..checkResult = LocationPermission.always
-      ..positionDelay = gpsTimeout + const Duration(milliseconds: 100)
+      ..positionDelay = gpsTimeout + _gpsOvershoot
       ..positionResult = fakePosition();
 
     await tester.pumpWidget(
@@ -502,14 +505,15 @@ void main() {
     );
 
     await tester.tap(find.text('Use My Location'));
-    await tester.pump(gpsTimeout + const Duration(milliseconds: 100));
+    await tester.pump(gpsTimeout + _gpsOvershoot);
     await tester.pumpAndSettle();
 
     expect(
       find.textContaining('GPS is not available on this device'),
       findsOneWidget,
     );
-  });
+  },
+  timeout: Timeout(gpsTimeout + _gpsTestBuffer));
 
   // -------------------------------------------------------------------------
   // CircularProgressIndicator during loading (line 300)

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -67,10 +67,7 @@ http.Client _geoClient({int status = 200, String? forwardBody}) {
     if (req.url.queryParameters.containsKey('q')) {
       return http.Response(fwd, status);
     }
-    return http.Response(
-      status == 200 ? _validReverseBody : '',
-      status,
-    );
+    return http.Response(status == 200 ? _validReverseBody : '', status);
   });
 }
 
@@ -390,28 +387,26 @@ void main() {
 
   testWidgets(
     'tapping Continue after confirm navigates to NotificationOnboardingScreen',
-    (
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+      await _tapContinueAfterManualEntry(tester);
+      expect(find.byType(NotificationOnboardingScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets('tapping Continue after confirm does not clear isFirstLaunch', (
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
       _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
     );
     await _tapContinueAfterManualEntry(tester);
-    expect(find.byType(NotificationOnboardingScreen), findsOneWidget);
+    final Preferences prefs = await Preferences.load();
+    // setFirstLaunchDone() moved to NotificationOnboardingScreen (issue #15).
+    expect(prefs.isFirstLaunch, isTrue);
   });
-
-  testWidgets(
-    'tapping Continue after confirm does not clear isFirstLaunch',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
-      );
-      await _tapContinueAfterManualEntry(tester);
-      final Preferences prefs = await Preferences.load();
-      // setFirstLaunchDone() moved to NotificationOnboardingScreen (issue #15).
-      expect(prefs.isFirstLaunch, isTrue);
-    },
-  );
 
   // -------------------------------------------------------------------------
   // Owned GeocodingApi creation (line 96: _ownedApi ??= GeocodingApi(...))

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -8,6 +8,9 @@ import 'package:uvalert/providers/location_provider.dart';
 
 import 'fakes/fake_geolocator.dart';
 
+const Duration _gpsOvershoot = Duration(milliseconds: 100);
+const Duration _gpsTestBuffer = Duration(seconds: 5);
+
 // Builds a ProviderContainer with a LocationNotifier wired to the given fake.
 // Using `overrideWith` lets us inject a custom notifier instance while keeping
 // the rest of the Riverpod graph untouched.
@@ -142,7 +145,7 @@ void main() {
     () async {
       final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
         ..checkResult = LocationPermission.always
-        ..positionDelay = gpsTimeout + const Duration(milliseconds: 100)
+        ..positionDelay = gpsTimeout + _gpsOvershoot
         ..positionResult = fakePosition();
 
       final ProviderContainer container = _makeContainer(platform);
@@ -153,7 +156,7 @@ void main() {
         throwsA(isA<TimeoutException>()),
       );
     },
-    timeout: Timeout(gpsTimeout + const Duration(seconds: 5)),
+    timeout: Timeout(gpsTimeout + _gpsTestBuffer),
   );
 
   // -------------------------------------------------------------------------

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -7,9 +7,7 @@ import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/location_provider.dart';
 
 import 'fakes/fake_geolocator.dart';
-
-const Duration _gpsOvershoot = Duration(milliseconds: 100);
-const Duration _gpsTestBuffer = Duration(seconds: 5);
+import 'helpers.dart';
 
 // Builds a ProviderContainer with a LocationNotifier wired to the given fake.
 // Using `overrideWith` lets us inject a custom notifier instance while keeping
@@ -145,7 +143,7 @@ void main() {
     () async {
       final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
         ..checkResult = LocationPermission.always
-        ..positionDelay = gpsTimeout + _gpsOvershoot
+        ..positionDelay = gpsTimeout + gpsOvershoot
         ..positionResult = fakePosition();
 
       final ProviderContainer container = _makeContainer(platform);
@@ -156,7 +154,7 @@ void main() {
         throwsA(isA<TimeoutException>()),
       );
     },
-    timeout: Timeout(gpsTimeout + _gpsTestBuffer),
+    timeout: Timeout(gpsTimeout + gpsTestBuffer),
   );
 
   // -------------------------------------------------------------------------

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/location_provider.dart';
 
 import 'fakes/fake_geolocator.dart';
@@ -129,6 +132,25 @@ void main() {
       );
     },
   );
+
+  // -------------------------------------------------------------------------
+  // fetchGps — timeout
+  // -------------------------------------------------------------------------
+
+  test('fetchGps throws TimeoutException when GPS hangs', () async {
+    final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+      ..checkResult = LocationPermission.always
+      ..positionDelay = apiDefaultTimeout + const Duration(milliseconds: 100)
+      ..positionResult = fakePosition();
+
+    final ProviderContainer container = _makeContainer(platform);
+    addTearDown(container.dispose);
+
+    await expectLater(
+      container.read(locationProvider.notifier).fetchGps(),
+      throwsA(isA<TimeoutException>()),
+    );
+  });
 
   // -------------------------------------------------------------------------
   // Default constructor — covers the ?? GeolocatorPlatform.instance fallback

--- a/test/location_provider_test.dart
+++ b/test/location_provider_test.dart
@@ -137,20 +137,24 @@ void main() {
   // fetchGps — timeout
   // -------------------------------------------------------------------------
 
-  test('fetchGps throws TimeoutException when GPS hangs', () async {
-    final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
-      ..checkResult = LocationPermission.always
-      ..positionDelay = apiDefaultTimeout + const Duration(milliseconds: 100)
-      ..positionResult = fakePosition();
+  test(
+    'fetchGps throws TimeoutException when GPS hangs',
+    () async {
+      final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+        ..checkResult = LocationPermission.always
+        ..positionDelay = gpsTimeout + const Duration(milliseconds: 100)
+        ..positionResult = fakePosition();
 
-    final ProviderContainer container = _makeContainer(platform);
-    addTearDown(container.dispose);
+      final ProviderContainer container = _makeContainer(platform);
+      addTearDown(container.dispose);
 
-    await expectLater(
-      container.read(locationProvider.notifier).fetchGps(),
-      throwsA(isA<TimeoutException>()),
-    );
-  });
+      await expectLater(
+        container.read(locationProvider.notifier).fetchGps(),
+        throwsA(isA<TimeoutException>()),
+      );
+    },
+    timeout: Timeout(gpsTimeout + const Duration(seconds: 5)),
+  );
 
   // -------------------------------------------------------------------------
   // Default constructor — covers the ?? GeolocatorPlatform.instance fallback

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -32,6 +32,7 @@ void main() {
 
   testWidgets('renders with an explicit key', (WidgetTester tester) async {
     final Key key = UniqueKey();
+
     await tester.pumpWidget(
       ProviderScope(
         child: MaterialApp(home: NotificationOnboardingScreen(key: key)),
@@ -158,8 +159,8 @@ void main() {
               AsyncValue<Preferences>.error(
                 Exception('prefs failed'),
                 StackTrace.empty,
-              ),
-            ),
+              )
+            )
           ],
           child: const MaterialApp(home: NotificationOnboardingScreen()),
         ),

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -72,9 +72,8 @@ void main() {
     final OnboardingProgressDots dots = tester.widget<OnboardingProgressDots>(
       find.byType(OnboardingProgressDots),
     );
-    expect(dots.current, equals(2));
+    expect(dots.current, equals(totalOnboardingSteps - 1));
     expect(dots.total, equals(totalOnboardingSteps));
-    expect(dots.total, equals(3));
   });
 
   // -------------------------------------------------------------------------

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -1,0 +1,188 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:uvalert/constants.dart';
+import 'package:uvalert/providers/preferences_provider.dart';
+import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/notification_onboarding_screen.dart';
+import 'package:uvalert/screens/onboarding_progress_dots.dart';
+import 'package:uvalert/storage/preferences.dart';
+
+// ---------------------------------------------------------------------------
+// Widget helper
+// ---------------------------------------------------------------------------
+
+Widget _wrap() => const ProviderScope(
+  child: MaterialApp(home: NotificationOnboardingScreen()),
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues(<String, Object>{});
+  });
+
+  // -------------------------------------------------------------------------
+  // Initial state
+  // -------------------------------------------------------------------------
+
+  testWidgets('renders with an explicit key', (WidgetTester tester) async {
+    final Key key = UniqueKey();
+    await tester.pumpWidget(
+      ProviderScope(
+        child: MaterialApp(home: NotificationOnboardingScreen(key: key)),
+      ),
+    );
+    expect(find.byKey(key), findsOneWidget);
+  });
+
+  testWidgets('shows Default Notifications and No Notifications options', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    expect(find.text('Default Notifications'), findsOneWidget);
+    expect(find.text('No Notifications'), findsOneWidget);
+  });
+
+  testWidgets('shows notifications header text', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap());
+    expect(find.text('Notifications'), findsOneWidget);
+  });
+
+  testWidgets('shows settings note text', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap());
+    expect(
+      find.textContaining('Notifications can be enabled'),
+      findsOneWidget,
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // Progress dots
+  // -------------------------------------------------------------------------
+
+  testWidgets('renders progress dots at step 3 of 3', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    final OnboardingProgressDots dots = tester.widget<OnboardingProgressDots>(
+      find.byType(OnboardingProgressDots),
+    );
+    expect(dots.current, equals(2));
+    expect(dots.total, equals(totalOnboardingSteps));
+    expect(dots.total, equals(3));
+  });
+
+  // -------------------------------------------------------------------------
+  // Default Notifications path
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'tapping Default Notifications navigates to DashboardScreen',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('Default Notifications'));
+      await tester.pumpAndSettle();
+      expect(find.byType(DashboardScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping Default Notifications sets notificationsEnabled to true',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('Default Notifications'));
+      await tester.pumpAndSettle();
+      final Preferences prefs = await Preferences.load();
+      expect(prefs.notificationsEnabled, isTrue);
+    },
+  );
+
+  testWidgets(
+    'tapping Default Notifications sets isFirstLaunch to false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('Default Notifications'));
+      await tester.pumpAndSettle();
+      final Preferences prefs = await Preferences.load();
+      expect(prefs.isFirstLaunch, isFalse);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // No Notifications path
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'tapping No Notifications navigates to DashboardScreen',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('No Notifications'));
+      await tester.pumpAndSettle();
+      expect(find.byType(DashboardScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping No Notifications leaves notificationsEnabled false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('No Notifications'));
+      await tester.pumpAndSettle();
+      final Preferences prefs = await Preferences.load();
+      expect(prefs.notificationsEnabled, isFalse);
+    },
+  );
+
+  testWidgets(
+    'tapping No Notifications sets isFirstLaunch to false',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(_wrap());
+      await tester.tap(find.text('No Notifications'));
+      await tester.pumpAndSettle();
+      final Preferences prefs = await Preferences.load();
+      expect(prefs.isFirstLaunch, isFalse);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Error path
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'shows snackbar and re-enables buttons when preferencesProvider throws',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          // ignore: always_specify_types (overrides list type not in flutter_riverpod public API)
+          overrides: [
+            preferencesProvider.overrideWithValue(
+              AsyncValue<Preferences>.error(
+                Exception('prefs failed'),
+                StackTrace.empty,
+              ),
+            ),
+          ],
+          child: const MaterialApp(home: NotificationOnboardingScreen()),
+        ),
+      );
+
+      await tester.tap(find.text('No Notifications'));
+      await tester.pump();
+      await tester.pump();
+
+      expect(
+        find.text('Something went wrong. Please try again.'),
+        findsOneWidget,
+      );
+
+      // Buttons must be re-enabled so the user can retry.
+      expect(find.text('Default Notifications'), findsOneWidget);
+      expect(find.text('No Notifications'), findsOneWidget);
+    },
+  );
+}

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -176,8 +176,12 @@ void main() {
       );
 
       // Buttons must be re-enabled so the user can retry.
-      expect(find.text('Default Notifications'), findsOneWidget);
-      expect(find.text('No Notifications'), findsOneWidget);
+      // Check onTap is non-null, not just that label text is present.
+      final List<InkWell> inkWells = tester
+          .widgetList<InkWell>(find.byType(InkWell))
+          .toList();
+      expect(inkWells, isNotEmpty);
+      expect(inkWells.every((InkWell w) => w.onTap != null), isTrue);
     },
   );
 }

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -158,8 +158,8 @@ void main() {
               AsyncValue<Preferences>.error(
                 Exception('prefs failed'),
                 StackTrace.empty,
-              )
-            )
+              ),
+            ),
           ],
           child: const MaterialApp(home: NotificationOnboardingScreen()),
         ),

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -158,8 +158,8 @@ void main() {
               AsyncValue<Preferences>.error(
                 Exception('prefs failed'),
                 StackTrace.empty,
-              ),
-            ),
+              )
+            )
           ],
           child: const MaterialApp(home: NotificationOnboardingScreen()),
         ),

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -55,7 +55,10 @@ void main() {
 
   testWidgets('shows settings note text', (WidgetTester tester) async {
     await tester.pumpWidget(_wrap());
-    expect(find.textContaining('Notifications can be enabled'), findsOneWidget);
+    expect(
+      find.textContaining('More notification options can be found in Settings'),
+      findsOneWidget,
+    );
   });
 
   // -------------------------------------------------------------------------

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -55,10 +55,7 @@ void main() {
 
   testWidgets('shows settings note text', (WidgetTester tester) async {
     await tester.pumpWidget(_wrap());
-    expect(
-      find.textContaining('Notifications can be enabled'),
-      findsOneWidget,
-    );
+    expect(find.textContaining('Notifications can be enabled'), findsOneWidget);
   });
 
   // -------------------------------------------------------------------------
@@ -80,15 +77,14 @@ void main() {
   // Default Notifications path
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'tapping Default Notifications navigates to DashboardScreen',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(_wrap());
-      await tester.tap(find.text('Default Notifications'));
-      await tester.pumpAndSettle();
-      expect(find.byType(DashboardScreen), findsOneWidget);
-    },
-  );
+  testWidgets('tapping Default Notifications navigates to DashboardScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.text('Default Notifications'));
+    await tester.pumpAndSettle();
+    expect(find.byType(DashboardScreen), findsOneWidget);
+  });
 
   testWidgets(
     'tapping Default Notifications sets notificationsEnabled to true',
@@ -101,52 +97,48 @@ void main() {
     },
   );
 
-  testWidgets(
-    'tapping Default Notifications sets isFirstLaunch to false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(_wrap());
-      await tester.tap(find.text('Default Notifications'));
-      await tester.pumpAndSettle();
-      final Preferences prefs = await Preferences.load();
-      expect(prefs.isFirstLaunch, isFalse);
-    },
-  );
+  testWidgets('tapping Default Notifications sets isFirstLaunch to false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.text('Default Notifications'));
+    await tester.pumpAndSettle();
+    final Preferences prefs = await Preferences.load();
+    expect(prefs.isFirstLaunch, isFalse);
+  });
 
   // -------------------------------------------------------------------------
   // No Notifications path
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'tapping No Notifications navigates to DashboardScreen',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(_wrap());
-      await tester.tap(find.text('No Notifications'));
-      await tester.pumpAndSettle();
-      expect(find.byType(DashboardScreen), findsOneWidget);
-    },
-  );
+  testWidgets('tapping No Notifications navigates to DashboardScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.text('No Notifications'));
+    await tester.pumpAndSettle();
+    expect(find.byType(DashboardScreen), findsOneWidget);
+  });
 
-  testWidgets(
-    'tapping No Notifications leaves notificationsEnabled false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(_wrap());
-      await tester.tap(find.text('No Notifications'));
-      await tester.pumpAndSettle();
-      final Preferences prefs = await Preferences.load();
-      expect(prefs.notificationsEnabled, isFalse);
-    },
-  );
+  testWidgets('tapping No Notifications leaves notificationsEnabled false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.text('No Notifications'));
+    await tester.pumpAndSettle();
+    final Preferences prefs = await Preferences.load();
+    expect(prefs.notificationsEnabled, isFalse);
+  });
 
-  testWidgets(
-    'tapping No Notifications sets isFirstLaunch to false',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(_wrap());
-      await tester.tap(find.text('No Notifications'));
-      await tester.pumpAndSettle();
-      final Preferences prefs = await Preferences.load();
-      expect(prefs.isFirstLaunch, isFalse);
-    },
-  );
+  testWidgets('tapping No Notifications sets isFirstLaunch to false', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.text('No Notifications'));
+    await tester.pumpAndSettle();
+    final Preferences prefs = await Preferences.load();
+    expect(prefs.isFirstLaunch, isFalse);
+  });
 
   // -------------------------------------------------------------------------
   // Error path

--- a/test/onboarding_screen_test.dart
+++ b/test/onboarding_screen_test.dart
@@ -6,6 +6,7 @@ import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/location_onboarding_screen.dart';
+import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_screen.dart';
 import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
@@ -89,6 +90,22 @@ void main() {
       );
       await pumpSplash(tester);
       expect(find.byType(LocationOnboardingScreen), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'routes to NotificationOnboardingScreen when location step done',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          prefs: <String, Object>{
+            Preferences.keyThemeStepDoneForTesting: true,
+            Preferences.keyLocationStepDoneForTesting: true,
+          },
+        ),
+      );
+      await pumpSplash(tester, hasSplashFloor: false);
+      expect(find.byType(NotificationOnboardingScreen), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
- Create the scaffold for the notification onboarding screen.

- Update routing in the onboarding flow to navigate to the notification onboarding screen after the location onboarding step.

- Move the `setFirstLaunchDone()` call to the notification onboarding screen.

- Increase the total onboarding steps from 2 to 3.

- Adjust the onboarding progress dots to reflect the new step count.

- Add widget tests for routing and progress dot count.



Fixes #15