### PR TITLE
feat(geocoding): add autocomplete and geocodeMultiple with debounced suggestion UI

### DIFF
--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -120,6 +120,10 @@ class GeocodingApi {
         throw GeocodingException(response.statusCode, response.body);
       }
 
+      if (decoded.isEmpty) {
+        throw const GeocodingNotFoundException();
+      }
+
       final List<GeocodingResult> results = <GeocodingResult>[];
 
       for (final Object? item in decoded) {
@@ -129,8 +133,10 @@ class GeocodingApi {
         if (result != null) results.add(result);
       }
 
+      // decoded was non-empty but every item failed field validation —
+      // this is a proxy schema change, not a "location not found" result.
       if (results.isEmpty) {
-        throw const GeocodingNotFoundException();
+        throw GeocodingException(response.statusCode, response.body);
       }
 
       return results;
@@ -160,34 +166,35 @@ class GeocodingApi {
     }
   }
 
-  static void _checkStatus(http.Response response) {
-    if (response.statusCode == httpNotFound) {
-      throw const GeocodingNotFoundException();
-    }
-    if (response.statusCode != httpOk) {
-      throw GeocodingException(response.statusCode, response.body);
-    }
+}
+
+void _checkStatus(http.Response response) {
+  if (response.statusCode == httpNotFound) {
+    throw const GeocodingNotFoundException();
+  }
+  if (response.statusCode != httpOk) {
+    throw GeocodingException(response.statusCode, response.body);
+  }
+}
+
+/// Parses one JSON object into a [GeocodingResult], or returns `null` if
+/// required fields are missing or have the wrong type.
+GeocodingResult? _itemToResult(Map<String, Object?> item) {
+  final Object? lat = item['lat'];
+  final Object? lon = item['lon'];
+  final Object? name = item['name'];
+  final Object? country = item['country'];
+  final Object? state = item['state'];
+
+  if (lat is! num || lon is! num || name is! String || country is! String) {
+    return null;
   }
 
-  /// Parses one JSON object into a [GeocodingResult], or returns `null` if
-  /// required fields are missing or have the wrong type.
-  static GeocodingResult? _itemToResult(Map<String, Object?> item) {
-    final Object? lat = item['lat'];
-    final Object? lon = item['lon'];
-    final Object? name = item['name'];
-    final Object? country = item['country'];
-    final Object? state = item['state'];
+  final String displayName = state is String
+      ? '$name, $state, $country'
+      : '$name, $country';
 
-    if (lat is! num || lon is! num || name is! String || country is! String) {
-      return null;
-    }
-
-    final String displayName = state is String
-        ? '$name, $state, $country'
-        : '$name, $country';
-
-    return (lat: lat.toDouble(), lon: lon.toDouble(), displayName: displayName);
-  }
+  return (lat: lat.toDouble(), lon: lon.toDouble(), displayName: displayName);
 }
 
 /// Thrown when the proxy returns 404 (location not found).

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -72,9 +72,7 @@ class GeocodingApi {
       _getResults(_geocodeUri, query);
 
   Future<List<GeocodingResult>> _getResults(Uri base, String query) async {
-    final Uri uri = base.replace(
-      queryParameters: <String, String>{'q': query},
-    );
+    final Uri uri = base.replace(queryParameters: <String, String>{'q': query});
 
     final http.Response response = await _httpClient
         .get(uri, headers: _headers)
@@ -160,7 +158,6 @@ class GeocodingApi {
       throw GeocodingException(response.statusCode, 'parse error: $e');
     }
   }
-
 }
 
 void _checkStatus(http.Response response) {

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -28,6 +28,9 @@ class GeocodingApi {
   }) : _geocodeUri = Uri.parse(
          '${stripTrailingSlash(proxyBaseUrl)}/api/geocode',
        ),
+       _autocompleteUri = Uri.parse(
+         '${stripTrailingSlash(proxyBaseUrl)}/api/autocomplete',
+       ),
        _deviceId = deviceId,
        _timeout = timeout,
        _ownsClient = httpClient == null,
@@ -38,6 +41,7 @@ class GeocodingApi {
   final http.Client _httpClient;
   final bool _ownsClient;
   final Uri _geocodeUri;
+  final Uri _autocompleteUri;
 
   late final Map<String, String> _headers = <String, String>{
     deviceIdHeader: _deviceId,
@@ -46,6 +50,23 @@ class GeocodingApi {
   /// Releases the underlying HTTP client if this instance owns it.
   void dispose() {
     if (_ownsClient) _httpClient.close();
+  }
+
+  /// Returns prefix-matched place suggestions for [query] via the autocomplete
+  /// endpoint (Photon/OSM-backed).
+  ///
+  /// Throws [GeocodingNotFoundException] when no suggestions are found (404).
+  /// Throws [GeocodingException] on any other non-200 response or parse error.
+  Future<List<GeocodingResult>> autocomplete(String query) async {
+    final Uri uri = _autocompleteUri.replace(
+      queryParameters: <String, String>{'q': query},
+    );
+
+    final http.Response response = await _httpClient
+        .get(uri, headers: _headers)
+        .timeout(_timeout);
+
+    return _parseResults(response);
   }
 
   /// Resolves a location [query] string (e.g. "Fresno") to a list of

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -57,17 +57,8 @@ class GeocodingApi {
   ///
   /// Throws [GeocodingNotFoundException] when no suggestions are found (404).
   /// Throws [GeocodingException] on any other non-200 response or parse error.
-  Future<List<GeocodingResult>> autocomplete(String query) async {
-    final Uri uri = _autocompleteUri.replace(
-      queryParameters: <String, String>{'q': query},
-    );
-
-    final http.Response response = await _httpClient
-        .get(uri, headers: _headers)
-        .timeout(_timeout);
-
-    return _parseResults(response);
-  }
+  Future<List<GeocodingResult>> autocomplete(String query) =>
+      _getResults(_autocompleteUri, query);
 
   /// Resolves a location [query] string (e.g. "Fresno") to a list of
   /// candidate matches, ordered by relevance.
@@ -76,8 +67,11 @@ class GeocodingApi {
   /// when the proxy returns 404 (no match) or the response contains no
   /// usable results. Throws [GeocodingException] on any other non-200
   /// response or parse error.
-  Future<List<GeocodingResult>> geocodeMultiple(String query) async {
-    final Uri uri = _geocodeUri.replace(
+  Future<List<GeocodingResult>> geocodeMultiple(String query) =>
+      _getResults(_geocodeUri, query);
+
+  Future<List<GeocodingResult>> _getResults(Uri base, String query) async {
+    final Uri uri = base.replace(
       queryParameters: <String, String>{'q': query},
     );
 

--- a/lib/api/geocoding_api.dart
+++ b/lib/api/geocoding_api.dart
@@ -55,7 +55,8 @@ class GeocodingApi {
   /// Returns prefix-matched place suggestions for [query] via the autocomplete
   /// endpoint (Photon/OSM-backed).
   ///
-  /// Throws [GeocodingNotFoundException] when no suggestions are found (404).
+  /// Throws [GeocodingNotFoundException] when no suggestions are found (404 or
+  /// a 200 response with an empty array).
   /// Throws [GeocodingException] on any other non-200 response or parse error.
   Future<List<GeocodingResult>> autocomplete(String query) =>
       _getResults(_autocompleteUri, query);

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -355,9 +355,12 @@ class _LocationOnboardingScreenState
   }
 
   void _onChangeLocation() {
+    _debounce?.cancel();
+    _operationId++;
     setState(() {
       _phase = _Phase.manual;
       _pending = null;
+      _suggestions = <GeocodingResult>[];
       _errorMessage = '';
     });
     _manualFocus.requestFocus();
@@ -427,51 +430,61 @@ class _LocationOnboardingScreenState
             vertical: onboardingPaddingVertical,
           ),
           child: Column(
-            spacing: onboardingSectionGap,
             children: <Widget>[
-              const Spacer(),
+              Expanded(
+                child: SingleChildScrollView(
+                  child: Column(
+                    spacing: onboardingSectionGap,
+                    children: <Widget>[
+                      const SizedBox(height: onboardingSectionGap),
 
-              const _Header(),
+                      const _Header(),
 
-              if (_phase == _Phase.idle) ...<Widget>[
-                _GpsButton(onPressed: onGpsPressed),
-                _ManualButton(onPressed: _onEnterManually),
-              ],
+                      if (_phase == _Phase.idle) ...<Widget>[
+                        _GpsButton(onPressed: onGpsPressed),
+                        _ManualButton(onPressed: _onEnterManually),
+                      ],
 
-              if (_phase == _Phase.loading)
-                const CircularProgressIndicator.adaptive(),
+                      if (_phase == _Phase.loading)
+                        const CircularProgressIndicator.adaptive(),
 
-              if (_phase == _Phase.manual || _phase == _Phase.geocoding)
-                _ManualEntryField(
-                  controller: _manualController,
-                  focusNode: _manualFocus,
-                  loading: _phase == _Phase.geocoding,
-                  onSearch: onManualSearch,
-                  onChanged: onChanged,
+                      if (_phase == _Phase.manual ||
+                          _phase == _Phase.geocoding)
+                        _ManualEntryField(
+                          controller: _manualController,
+                          focusNode: _manualFocus,
+                          loading: _phase == _Phase.geocoding,
+                          onSearch: onManualSearch,
+                          onChanged: onChanged,
+                        ),
+
+                      if (_phase == _Phase.manual && _suggestions.isNotEmpty)
+                        _SuggestionList(
+                          suggestions: _suggestions,
+                          onPick: _onPick,
+                        ),
+
+                      if (_phase == _Phase.picking)
+                        _PickList(
+                          candidates: _candidates,
+                          onPick: _onPick,
+                          onSearchAgain: _onSearchAgain,
+                        ),
+
+                      if (_phase == _Phase.confirm)
+                        _ConfirmCard(
+                          displayName: _pending!.result.displayName,
+                          onChange: _onChangeLocation,
+                        ),
+
+                      if (_errorMessage.isNotEmpty)
+                        _ErrorText(message: _errorMessage),
+
+                      const SizedBox(height: onboardingSectionGap),
+                    ],
+                  ),
                 ),
-
-              if (_phase == _Phase.manual && _suggestions.isNotEmpty)
-                _SuggestionList(
-                  suggestions: _suggestions,
-                  onPick: _onPick,
-                ),
-
-              if (_phase == _Phase.picking)
-                _PickList(
-                  candidates: _candidates,
-                  onPick: _onPick,
-                  onSearchAgain: _onSearchAgain,
-                ),
-
-              if (_phase == _Phase.confirm)
-                _ConfirmCard(
-                  displayName: _pending!.result.displayName,
-                  onChange: _onChangeLocation,
-                ),
-
-              if (_errorMessage.isNotEmpty) _ErrorText(message: _errorMessage),
-
-              const Spacer(),
+              ),
 
               const OnboardingProgressDots(
                 current: _locationScreenIndex,
@@ -690,7 +703,6 @@ class _PickList extends StatelessWidget {
                 onboardingPickListMaxHeightFraction,
           ),
           child: ListView(
-            shrinkWrap: true,
             children: candidates
                 .map(
                   (GeocodingResult r) => Padding(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -124,6 +124,7 @@ class _LocationOnboardingScreenState
   // -------------------------------------------------------------------------
 
   Future<void> _onUseMyLocation(String proxyBaseUrl, String deviceId) async {
+    _debounce?.cancel();
     final int opId = ++_operationId;
 
     setState(() {
@@ -197,6 +198,7 @@ class _LocationOnboardingScreenState
 
   void _onChanged(String value, String proxyBaseUrl, String deviceId) {
     _debounce?.cancel();
+    _operationId++;
 
     setState(() {
       _suggestions = <GeocodingResult>[];
@@ -204,8 +206,6 @@ class _LocationOnboardingScreenState
     });
 
     if (value.trim().length < _minQueryLength) return;
-
-    _operationId++;
 
     _debounce = Timer(
       const Duration(milliseconds: _debounceMs),
@@ -773,8 +773,6 @@ class _SuggestionList extends StatelessWidget {
             onboardingPickListMaxHeightFraction,
       ),
       child: ListView.separated(
-        shrinkWrap: true,
-        physics: const NeverScrollableScrollPhysics(),
         itemCount: suggestions.length,
         separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
         itemBuilder: (_, int i) => SizedBox(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -200,16 +200,20 @@ class _LocationOnboardingScreenState
     _debounce?.cancel();
     _operationId++;
 
-    setState(() {
-      _suggestions = <GeocodingResult>[];
-      _errorMessage = '';
-    });
+    if (_suggestions.isNotEmpty || _errorMessage.isNotEmpty) {
+      setState(() {
+        _suggestions = <GeocodingResult>[];
+        _errorMessage = '';
+      });
+    }
 
-    if (value.trim().length < _minQueryLength) return;
+    final String trimmed = value.trim();
+    
+    if (trimmed.length < _minQueryLength) return;
 
     _debounce = Timer(
       const Duration(milliseconds: _debounceMs),
-      () => _onDebounced(value.trim(), proxyBaseUrl, deviceId),
+      () => _onDebounced(trimmed, proxyBaseUrl, deviceId),
     );
   }
 
@@ -704,6 +708,35 @@ class _ConfirmCard extends StatelessWidget {
   }
 }
 
+class _ResultListView extends StatelessWidget {
+  const _ResultListView({required this.items, required this.onPick});
+
+  final List<GeocodingResult> items;
+  final ValueChanged<GeocodingResult> onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight:
+            MediaQuery.sizeOf(context).height *
+            onboardingPickListMaxHeightFraction,
+      ),
+      child: ListView.separated(
+        itemCount: items.length,
+        separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
+        itemBuilder: (_, int i) => SizedBox(
+          width: double.infinity,
+          child: OutlinedButton(
+            onPressed: () => onPick(items[i]),
+            child: Text(items[i].displayName, textAlign: TextAlign.center),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _PickList extends StatelessWidget {
   const _PickList({
     required this.candidates,
@@ -722,28 +755,7 @@ class _PickList extends StatelessWidget {
       spacing: onboardingItemGap,
       children: <Widget>[
         Text('Select your location:', style: theme.textTheme.bodyMedium),
-        ConstrainedBox(
-          constraints: BoxConstraints(
-            maxHeight:
-                MediaQuery.sizeOf(context).height *
-                onboardingPickListMaxHeightFraction,
-          ),
-          child: ListView.separated(
-            itemCount: candidates.length,
-            separatorBuilder: (_, _) =>
-                const SizedBox(height: onboardingItemGap),
-            itemBuilder: (_, int i) => SizedBox(
-              width: double.infinity,
-              child: OutlinedButton(
-                onPressed: () => onPick(candidates[i]),
-                child: Text(
-                  candidates[i].displayName,
-                  textAlign: TextAlign.center,
-                ),
-              ),
-            ),
-          ),
-        ),
+        _ResultListView(items: candidates, onPick: onPick),
         Text(
           'Not your city? Try adding region and country'
           ' (e.g. "Washington, DC, US" or "London, England, GB").',
@@ -765,29 +777,8 @@ class _SuggestionList extends StatelessWidget {
   final ValueChanged<GeocodingResult> onPick;
 
   @override
-  Widget build(BuildContext context) {
-    return ConstrainedBox(
-      constraints: BoxConstraints(
-        maxHeight:
-            MediaQuery.sizeOf(context).height *
-            onboardingPickListMaxHeightFraction,
-      ),
-      child: ListView.separated(
-        itemCount: suggestions.length,
-        separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
-        itemBuilder: (_, int i) => SizedBox(
-          width: double.infinity,
-          child: OutlinedButton(
-            onPressed: () => onPick(suggestions[i]),
-            child: Text(
-              suggestions[i].displayName,
-              textAlign: TextAlign.center,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) =>
+      _ResultListView(items: suggestions, onPick: onPick);
 }
 
 class _ErrorText extends StatelessWidget {

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -193,11 +193,14 @@ class _LocationOnboardingScreenState
 
   void _onChanged(String value, String proxyBaseUrl, String deviceId) {
     _debounce?.cancel();
+
     setState(() {
       _suggestions = <GeocodingResult>[];
       _errorMessage = '';
     });
+
     if (value.trim().length < _minQueryLength) return;
+
     _debounce = Timer(
       const Duration(milliseconds: _debounceMs),
       () => _onDebounced(value.trim(), proxyBaseUrl, deviceId),
@@ -210,6 +213,7 @@ class _LocationOnboardingScreenState
     String deviceId,
   ) async {
     final int opId = _operationId;
+
     try {
       final List<GeocodingResult> results = await _geocodingApi(
         proxyBaseUrl,
@@ -217,13 +221,17 @@ class _LocationOnboardingScreenState
       ).autocomplete(query);
 
       if (!mounted || _operationId != opId) return;
+      
       setState(() => _suggestions = results);
     } on GeocodingNotFoundException {
       if (!mounted || _operationId != opId) return;
+
       setState(() => _suggestions = <GeocodingResult>[]);
     } on Object catch (e, st) {
       debugPrint('Autocomplete error: $e\n$st');
+
       if (!mounted || _operationId != opId) return;
+
       setState(() => _suggestions = <GeocodingResult>[]);
     }
   }
@@ -234,6 +242,7 @@ class _LocationOnboardingScreenState
     if (query.isEmpty) return;
 
     final int opId = ++_operationId;
+
     setState(() {
       _phase = _Phase.geocoding;
       _errorMessage = '';
@@ -257,6 +266,7 @@ class _LocationOnboardingScreenState
       }
     } on GeocodingNotFoundException {
       if (!mounted || _operationId != opId) return;
+
       setState(() {
         _phase = _Phase.manual;
         _suggestions = <GeocodingResult>[];
@@ -264,9 +274,12 @@ class _LocationOnboardingScreenState
             'Location not found. Try adding region and country'
             ' (e.g. "Washington, DC, US" or "London, England, GB").';
       });
+
     } on Object catch (e, st) {
       debugPrint('Manual geocoding error: $e\n$st');
+
       if (!mounted || _operationId != opId) return;
+
       setState(() {
         _phase = _Phase.manual;
         _suggestions = <GeocodingResult>[];
@@ -277,12 +290,8 @@ class _LocationOnboardingScreenState
 
   void _onPick(GeocodingResult result) {
     _debounce?.cancel();
-    setState(() {
-      _pending = (result: result, fromGps: false);
-      _candidates = <GeocodingResult>[];
-      _suggestions = <GeocodingResult>[];
-      _phase = _Phase.confirm;
-    });
+
+    _setConfirmed(result, fromGps: false);
   }
 
   void _setConfirmed(GeocodingResult result, {required bool fromGps}) {
@@ -302,6 +311,7 @@ class _LocationOnboardingScreenState
       _suggestions = <GeocodingResult>[];
       _phase = _Phase.manual;
       _errorMessage = '';
+      _continuing = false;
     });
     _manualFocus.requestFocus();
   }
@@ -332,6 +342,7 @@ class _LocationOnboardingScreenState
           .setManual(lat: confirmed.result.lat, lon: confirmed.result.lon);
 
       final Preferences prefs = await ref.read(preferencesProvider.future);
+
       await prefs.setLocationStepDone();
 
       if (!mounted) return;
@@ -345,7 +356,9 @@ class _LocationOnboardingScreenState
       );
     } on Object catch (e, st) {
       debugPrint('Confirm error: $e\n$st');
+
       if (!mounted || _operationId != opId) return;
+
       setState(() {
         _continuing = false;
         _phase = _Phase.confirm;
@@ -357,12 +370,15 @@ class _LocationOnboardingScreenState
   void _onChangeLocation() {
     _debounce?.cancel();
     _operationId++;
+
     setState(() {
       _phase = _Phase.manual;
       _pending = null;
       _suggestions = <GeocodingResult>[];
       _errorMessage = '';
+      _continuing = false;
     });
+
     _manualFocus.requestFocus();
   }
 
@@ -374,12 +390,14 @@ class _LocationOnboardingScreenState
     _debounce?.cancel();
     _operationId++;
     _manualController.clear();
+    
     setState(() {
       _phase = _Phase.idle;
       _candidates = <GeocodingResult>[];
       _suggestions = <GeocodingResult>[];
       _errorMessage = '';
       _pending = null;
+      _continuing = false;
     });
   }
 
@@ -430,6 +448,7 @@ class _LocationOnboardingScreenState
             vertical: onboardingPaddingVertical,
           ),
           child: Column(
+            spacing: onboardingSectionGap,
             children: <Widget>[
               Expanded(
                 child: SingleChildScrollView(
@@ -702,18 +721,21 @@ class _PickList extends StatelessWidget {
             maxHeight: MediaQuery.sizeOf(context).height *
                 onboardingPickListMaxHeightFraction,
           ),
-          child: ListView(
-            children: candidates
-                .map(
-                  (GeocodingResult r) => Padding(
-                    padding: const EdgeInsets.only(bottom: onboardingItemGap),
-                    child: OutlinedButton(
-                      onPressed: () => onPick(r),
-                      child: Text(r.displayName, textAlign: TextAlign.center),
-                    ),
-                  ),
-                )
-                .toList(),
+          child: ListView.separated(
+            physics: const NeverScrollableScrollPhysics(),
+            itemCount: candidates.length,
+            separatorBuilder: (_, _) =>
+                const SizedBox(height: onboardingItemGap),
+            itemBuilder: (_, int i) => SizedBox(
+              width: double.infinity,
+              child: OutlinedButton(
+                onPressed: () => onPick(candidates[i]),
+                child: Text(
+                  candidates[i].displayName,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
           ),
         ),
         Text(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -193,6 +193,7 @@ class _LocationOnboardingScreenState
 
   void _onChanged(String value, String proxyBaseUrl, String deviceId) {
     _debounce?.cancel();
+    _operationId++;
 
     setState(() {
       _suggestions = <GeocodingResult>[];
@@ -237,6 +238,8 @@ class _LocationOnboardingScreenState
   }
 
   Future<void> _onGeocodeManual(String proxyBaseUrl, String deviceId) async {
+    _debounce?.cancel();
+
     final String query = _manualController.text.trim();
 
     if (query.isEmpty) return;
@@ -344,7 +347,7 @@ class _LocationOnboardingScreenState
 
       await prefs.setLocationStepDone();
 
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       unawaited(
         Navigator.of(context).pushReplacement(
@@ -721,7 +724,6 @@ class _PickList extends StatelessWidget {
                 onboardingPickListMaxHeightFraction,
           ),
           child: ListView.separated(
-            physics: const NeverScrollableScrollPhysics(),
             itemCount: candidates.length,
             separatorBuilder: (_, _) =>
                 const SizedBox(height: onboardingItemGap),

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -315,6 +315,7 @@ class _LocationOnboardingScreenState
 
     assert(_pending != null, '_onConfirm called outside confirm phase');
 
+    final int opId = ++_operationId;
     final _ConfirmResult confirmed = _pending!;
 
     try {
@@ -342,8 +343,9 @@ class _LocationOnboardingScreenState
           ),
         ),
       );
-    } on Object {
-      if (!mounted) return;
+    } on Object catch (e, st) {
+      debugPrint('Confirm error: $e\n$st');
+      if (!mounted || _operationId != opId) return;
       setState(() {
         _continuing = false;
         _phase = _Phase.confirm;

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -221,7 +221,7 @@ class _LocationOnboardingScreenState
       ).autocomplete(query);
 
       if (!mounted || _operationId != opId) return;
-      
+
       setState(() => _suggestions = results);
     } on GeocodingNotFoundException {
       if (!mounted || _operationId != opId) return;
@@ -274,7 +274,6 @@ class _LocationOnboardingScreenState
             'Location not found. Try adding region and country'
             ' (e.g. "Washington, DC, US" or "London, England, GB").';
       });
-
     } on Object catch (e, st) {
       debugPrint('Manual geocoding error: $e\n$st');
 
@@ -390,7 +389,7 @@ class _LocationOnboardingScreenState
     _debounce?.cancel();
     _operationId++;
     _manualController.clear();
-    
+
     setState(() {
       _phase = _Phase.idle;
       _candidates = <GeocodingResult>[];
@@ -467,8 +466,7 @@ class _LocationOnboardingScreenState
                       if (_phase == _Phase.loading)
                         const CircularProgressIndicator.adaptive(),
 
-                      if (_phase == _Phase.manual ||
-                          _phase == _Phase.geocoding)
+                      if (_phase == _Phase.manual || _phase == _Phase.geocoding)
                         _ManualEntryField(
                           controller: _manualController,
                           focusNode: _manualFocus,
@@ -718,7 +716,8 @@ class _PickList extends StatelessWidget {
         Text('Select your location:', style: theme.textTheme.bodyMedium),
         ConstrainedBox(
           constraints: BoxConstraints(
-            maxHeight: MediaQuery.sizeOf(context).height *
+            maxHeight:
+                MediaQuery.sizeOf(context).height *
                 onboardingPickListMaxHeightFraction,
           ),
           child: ListView.separated(
@@ -769,10 +768,7 @@ class _SuggestionList extends StatelessWidget {
         width: double.infinity,
         child: OutlinedButton(
           onPressed: () => onPick(suggestions[i]),
-          child: Text(
-            suggestions[i].displayName,
-            textAlign: TextAlign.center,
-          ),
+          child: Text(suggestions[i].displayName, textAlign: TextAlign.center),
         ),
       ),
     );

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -22,6 +22,9 @@ const int _locationScreenIndex = 1;
 
 const double _spinnerSize = 16;
 const double _spinnerStrokeWidth = 2;
+const int _debounceMs = 400;
+const int _minQueryLength = 2;
+const double _appBarElevation = 0;
 
 // ---------------------------------------------------------------------------
 // Confirm result
@@ -87,7 +90,13 @@ class _LocationOnboardingScreenState
   bool _continuing = false;
   _ConfirmResult? _pending;
   List<GeocodingResult> _candidates = <GeocodingResult>[];
+  List<GeocodingResult> _suggestions = <GeocodingResult>[];
   String _errorMessage = '';
+  Timer? _debounce;
+  // Incremented whenever the user navigates away (back, search-again, change).
+  // Async callbacks capture this value before their await and discard their
+  // result if the counter has advanced, preventing stale state overwrites.
+  int _operationId = 0;
 
   final TextEditingController _manualController = TextEditingController();
   final FocusNode _manualFocus = FocusNode();
@@ -103,6 +112,7 @@ class _LocationOnboardingScreenState
 
   @override
   void dispose() {
+    _debounce?.cancel();
     _manualController.dispose();
     _manualFocus.dispose();
     _ownedApi?.dispose();
@@ -181,11 +191,49 @@ class _LocationOnboardingScreenState
     _manualFocus.requestFocus();
   }
 
+  void _onChanged(String value, String proxyBaseUrl, String deviceId) {
+    _debounce?.cancel();
+    setState(() {
+      _suggestions = <GeocodingResult>[];
+      _errorMessage = '';
+    });
+    if (value.trim().length < _minQueryLength) return;
+    _debounce = Timer(
+      const Duration(milliseconds: _debounceMs),
+      () => _onDebounced(value.trim(), proxyBaseUrl, deviceId),
+    );
+  }
+
+  Future<void> _onDebounced(
+    String query,
+    String proxyBaseUrl,
+    String deviceId,
+  ) async {
+    final int opId = _operationId;
+    try {
+      final List<GeocodingResult> results = await _geocodingApi(
+        proxyBaseUrl,
+        deviceId,
+      ).autocomplete(query);
+
+      if (!mounted || _operationId != opId) return;
+      setState(() => _suggestions = results);
+    } on GeocodingNotFoundException {
+      if (!mounted || _operationId != opId) return;
+      setState(() => _suggestions = <GeocodingResult>[]);
+    } on Object catch (e, st) {
+      debugPrint('Autocomplete error: $e\n$st');
+      if (!mounted || _operationId != opId) return;
+      setState(() => _suggestions = <GeocodingResult>[]);
+    }
+  }
+
   Future<void> _onGeocodeManual(String proxyBaseUrl, String deviceId) async {
     final String query = _manualController.text.trim();
 
     if (query.isEmpty) return;
 
+    final int opId = ++_operationId;
     setState(() {
       _phase = _Phase.geocoding;
       _errorMessage = '';
@@ -197,7 +245,7 @@ class _LocationOnboardingScreenState
         deviceId,
       ).geocodeMultiple(query);
 
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       if (results.length == 1) {
         _setConfirmed(results.first, fromGps: false);
@@ -208,33 +256,52 @@ class _LocationOnboardingScreenState
         });
       }
     } on GeocodingNotFoundException {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
       setState(() {
         _phase = _Phase.manual;
+        _suggestions = <GeocodingResult>[];
         _errorMessage =
             'Location not found. Try adding region and country'
             ' (e.g. "Washington, DC, US" or "London, England, GB").';
       });
-    } on Object {
-      if (!mounted) return;
+    } on Object catch (e, st) {
+      debugPrint('Manual geocoding error: $e\n$st');
+      if (!mounted || _operationId != opId) return;
       setState(() {
         _phase = _Phase.manual;
+        _suggestions = <GeocodingResult>[];
         _errorMessage = 'Something went wrong. Please try again.';
       });
     }
   }
 
+  void _onPick(GeocodingResult result) {
+    _debounce?.cancel();
+    setState(() {
+      _pending = (result: result, fromGps: false);
+      _candidates = <GeocodingResult>[];
+      _suggestions = <GeocodingResult>[];
+      _phase = _Phase.confirm;
+    });
+  }
+
   void _setConfirmed(GeocodingResult result, {required bool fromGps}) {
     setState(() {
       _candidates = <GeocodingResult>[];
+      _suggestions = <GeocodingResult>[];
       _pending = (result: result, fromGps: fromGps);
       _phase = _Phase.confirm;
     });
   }
 
   void _onSearchAgain() {
+    _debounce?.cancel();
+    _operationId++;
     setState(() {
+      _candidates = <GeocodingResult>[];
+      _suggestions = <GeocodingResult>[];
       _phase = _Phase.manual;
+      _errorMessage = '';
     });
     _manualFocus.requestFocus();
   }
@@ -298,6 +365,19 @@ class _LocationOnboardingScreenState
   // Helpers
   // -------------------------------------------------------------------------
 
+  void _onBack() {
+    _debounce?.cancel();
+    _operationId++;
+    _manualController.clear();
+    setState(() {
+      _phase = _Phase.idle;
+      _candidates = <GeocodingResult>[];
+      _suggestions = <GeocodingResult>[];
+      _errorMessage = '';
+      _pending = null;
+    });
+  }
+
   void _setError(String message) {
     setState(() {
       _phase = _Phase.idle;
@@ -324,7 +404,20 @@ class _LocationOnboardingScreenState
         ? null
         : () => _onGeocodeManual(proxyBaseUrl, deviceId);
 
+    final ValueChanged<String>? onChanged = deviceId == null
+        ? null
+        : (String v) => _onChanged(v, proxyBaseUrl, deviceId);
+
+    final bool canGoBack = _phase != _Phase.idle && _phase != _Phase.loading;
+
     return Scaffold(
+      appBar: canGoBack
+          ? AppBar(
+              leading: BackButton(onPressed: _onBack),
+              backgroundColor: Colors.transparent,
+              elevation: _appBarElevation,
+            )
+          : null,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(
@@ -352,13 +445,19 @@ class _LocationOnboardingScreenState
                   focusNode: _manualFocus,
                   loading: _phase == _Phase.geocoding,
                   onSearch: onManualSearch,
+                  onChanged: onChanged,
+                ),
+
+              if (_phase == _Phase.manual && _suggestions.isNotEmpty)
+                _SuggestionList(
+                  suggestions: _suggestions,
+                  onPick: _onPick,
                 ),
 
               if (_phase == _Phase.picking)
                 _PickList(
                   candidates: _candidates,
-                  onPick: (GeocodingResult r) =>
-                      _setConfirmed(r, fromGps: false),
+                  onPick: _onPick,
                   onSearchAgain: _onSearchAgain,
                 ),
 
@@ -461,6 +560,7 @@ class _ManualEntryField extends StatelessWidget {
     required this.focusNode,
     required this.loading,
     required this.onSearch,
+    required this.onChanged,
   });
 
   final TextEditingController controller;
@@ -470,6 +570,7 @@ class _ManualEntryField extends StatelessWidget {
   // which this widget never uses. The adapter (_) => onSearch!() is derived
   // here from onSearch so the caller stays free of that boilerplate.
   final VoidCallback? onSearch;
+  final ValueChanged<String>? onChanged;
 
   @override
   Widget build(BuildContext context) {
@@ -478,6 +579,7 @@ class _ManualEntryField extends StatelessWidget {
       focusNode: focusNode,
       enabled: !loading,
       textInputAction: TextInputAction.search,
+      onChanged: onChanged,
       onSubmitted: onSearch == null ? null : (_) => onSearch!(),
       decoration: InputDecoration(
         hintText: 'City, Region, Country (e.g. Washington, DC, US)',
@@ -610,6 +712,33 @@ class _PickList extends StatelessWidget {
         ),
         TextButton(onPressed: onSearchAgain, child: const Text('Search again')),
       ],
+    );
+  }
+}
+
+class _SuggestionList extends StatelessWidget {
+  const _SuggestionList({required this.suggestions, required this.onPick});
+
+  final List<GeocodingResult> suggestions;
+  final ValueChanged<GeocodingResult> onPick;
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.separated(
+      shrinkWrap: true,
+      physics: const NeverScrollableScrollPhysics(),
+      itemCount: suggestions.length,
+      separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
+      itemBuilder: (_, int i) => SizedBox(
+        width: double.infinity,
+        child: OutlinedButton(
+          onPressed: () => onPick(suggestions[i]),
+          child: Text(
+            suggestions[i].displayName,
+            textAlign: TextAlign.center,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -124,6 +124,8 @@ class _LocationOnboardingScreenState
   // -------------------------------------------------------------------------
 
   Future<void> _onUseMyLocation(String proxyBaseUrl, String deviceId) async {
+    final int opId = ++_operationId;
+
     setState(() {
       _phase = _Phase.loading;
       _errorMessage = '';
@@ -132,7 +134,7 @@ class _LocationOnboardingScreenState
     try {
       await ref.read(locationProvider.notifier).fetchGps();
 
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       final LocationState loc = ref.read(locationProvider);
 
@@ -151,30 +153,32 @@ class _LocationOnboardingScreenState
           deviceId,
         ).reverseGeocode(lat: loc.lat, lon: loc.lon);
       } on TimeoutException {
-        if (!mounted) return;
+        if (!mounted || _operationId != opId) return;
         _setError('Could not determine your city. Try entering it manually.');
         return;
       }
 
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       _setConfirmed(result, fromGps: true);
     } on PermissionDeniedException {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
       // Permission denied; fall through to manual entry.
       setState(() => _phase = _Phase.manual);
       _manualFocus.requestFocus();
     } on TimeoutException {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
+      // TimeoutException fires when GPS cannot acquire a fix within gpsTimeout.
+      // This covers both "no GPS hardware" and "weak signal / indoors".
       _setError(
-        'GPS is not available on this device. '
-        'Try entering your location manually.',
+        'Could not get a GPS fix. '
+        'Move outdoors or enter your location manually.',
       );
     } on GeocodingNotFoundException {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
       _setError('Could not determine your city. Try entering it manually.');
     } on Object {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
       _setError('Something went wrong. Please try again.');
     }
   }
@@ -193,7 +197,6 @@ class _LocationOnboardingScreenState
 
   void _onChanged(String value, String proxyBaseUrl, String deviceId) {
     _debounce?.cancel();
-    _operationId++;
 
     setState(() {
       _suggestions = <GeocodingResult>[];
@@ -201,6 +204,8 @@ class _LocationOnboardingScreenState
     });
 
     if (value.trim().length < _minQueryLength) return;
+
+    _operationId++;
 
     _debounce = Timer(
       const Duration(milliseconds: _debounceMs),
@@ -761,16 +766,26 @@ class _SuggestionList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListView.separated(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      itemCount: suggestions.length,
-      separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
-      itemBuilder: (_, int i) => SizedBox(
-        width: double.infinity,
-        child: OutlinedButton(
-          onPressed: () => onPick(suggestions[i]),
-          child: Text(suggestions[i].displayName, textAlign: TextAlign.center),
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        maxHeight:
+            MediaQuery.sizeOf(context).height *
+            onboardingPickListMaxHeightFraction,
+      ),
+      child: ListView.separated(
+        shrinkWrap: true,
+        physics: const NeverScrollableScrollPhysics(),
+        itemCount: suggestions.length,
+        separatorBuilder: (_, _) => const SizedBox(height: onboardingItemGap),
+        itemBuilder: (_, int i) => SizedBox(
+          width: double.infinity,
+          child: OutlinedButton(
+            onPressed: () => onPick(suggestions[i]),
+            child: Text(
+              suggestions[i].displayName,
+              textAlign: TextAlign.center,
+            ),
+          ),
         ),
       ),
     );

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -208,7 +208,6 @@ class _LocationOnboardingScreenState
     }
 
     final String trimmed = value.trim();
-    
     if (trimmed.length < _minQueryLength) return;
 
     _debounce = Timer(

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -208,6 +208,7 @@ class _LocationOnboardingScreenState
     }
 
     final String trimmed = value.trim();
+
     if (trimmed.length < _minQueryLength) return;
 
     _debounce = Timer(

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -44,7 +44,10 @@ class _NotificationOnboardingScreenState
     unawaited(_advance(notificationsEnabled: notificationsEnabled));
   }
 
+  int _operationId = 0;
+
   Future<void> _advance({required bool notificationsEnabled}) async {
+    final int opId = ++_operationId;
     setState(() => _continuing = true);
 
     try {
@@ -52,11 +55,13 @@ class _NotificationOnboardingScreenState
           .read(settingsProvider.notifier)
           .setNotificationsEnabled(value: notificationsEnabled);
 
+      if (!mounted || _operationId != opId) return;
+
       final Preferences prefs = await ref.read(preferencesProvider.future);
 
       await prefs.setFirstLaunchDone();
 
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       unawaited(
         Navigator.of(context).pushReplacement(
@@ -64,7 +69,7 @@ class _NotificationOnboardingScreenState
         ),
       );
     } on Object {
-      if (!mounted) return;
+      if (!mounted || _operationId != opId) return;
 
       setState(() => _continuing = false);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   workmanager: ^0.9.0+3
 
 dev_dependencies:
-  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,7 @@ dependencies:
   workmanager: ^0.9.0+3
 
 dev_dependencies:
+  fake_async: ^1.3.3
   flutter_test:
     sdk: flutter
   mocktail: ^1.0.4

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -286,23 +286,23 @@ void main() {
       );
     });
 
-    test('throws GeocodingException when required fields are missing',
-        () async {
-      final GeocodingApi api = _makeApi(
-        mockClientReturning(200, '{"lat":36.75,"lon":-119.65}'),
-      );
-      addTearDown(api.dispose);
+    test(
+      'throws GeocodingException when required fields are missing',
+      () async {
+        final GeocodingApi api = _makeApi(
+          mockClientReturning(200, '{"lat":36.75,"lon":-119.65}'),
+        );
+        addTearDown(api.dispose);
 
-      await expectLater(
-        api.reverseGeocode(lat: 36.75, lon: -119.65),
-        throwsA(isA<GeocodingException>()),
-      );
-    });
+        await expectLater(
+          api.reverseGeocode(lat: 36.75, lon: -119.65),
+          throwsA(isA<GeocodingException>()),
+        );
+      },
+    );
 
     test('throws GeocodingException on malformed JSON body', () async {
-      final GeocodingApi api = _makeApi(
-        mockClientReturning(200, '{not json}'),
-      );
+      final GeocodingApi api = _makeApi(mockClientReturning(200, '{not json}'));
       addTearDown(api.dispose);
 
       await expectLater(

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -264,6 +264,18 @@ void main() {
       expect(capturedHeaders?[deviceIdHeader], 'test-device-id');
     });
 
+    test('throws GeocodingException on non-200/404 status', () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(500, 'server error'),
+      );
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.reverseGeocode(lat: 36.75, lon: -119.65),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
+
     test('throws GeocodingException when body is not a JSON object', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(200, '"string"'));
       addTearDown(api.dispose);

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -156,6 +156,21 @@ void main() {
       );
     });
 
+    test(
+      'throws GeocodingException when all items have missing required fields',
+      () async {
+        final GeocodingApi api = _makeApi(
+          mockClientReturning(200, '[{"lat":36.75,"lon":-119.65}]'),
+        );
+        addTearDown(api.dispose);
+
+        await expectLater(
+          api.geocodeMultiple('Fresno, CA'),
+          throwsA(isA<GeocodingException>()),
+        );
+      },
+    );
+
     test('sends query as q parameter', () async {
       Uri? captured;
       final MockClient client = MockClient((http.Request req) async {

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -30,6 +30,12 @@ const String _validBodyMultiple =
     '{"lat":42.9,"lon":-81.2,"name":"London",'
     '"country":"CA","state":"Ontario"}]';
 
+const String _validArrayMultiple =
+    '[{"lat":34.06,"lon":-117.64,"name":"Ontario",'
+    '"country":"US","state":"California"},'
+    '{"lat":44.02,"lon":-116.96,"name":"Ontario",'
+    '"country":"US","state":"Oregon"}]';
+
 // reverseGeocode uses a single-object response (separate OWM endpoint).
 const String _reverseBodyWithState =
     '{"lat":36.75,"lon":-119.65,'
@@ -86,12 +92,36 @@ void main() {
       },
     );
 
+    test('returns multiple results (Ontario)', () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(200, _validArrayMultiple),
+      );
+      addTearDown(api.dispose);
+      final List<GeocodingResult> results = await api.geocodeMultiple(
+        'Ontario',
+      );
+
+      expect(results, hasLength(2));
+      expect(results[0].displayName, 'Ontario, California, US');
+      expect(results[1].displayName, 'Ontario, Oregon, US');
+    });
+
     test('throws GeocodingNotFoundException on 404', () async {
       final GeocodingApi api = _makeApi(mockClientReturning(404, 'not found'));
       addTearDown(api.dispose);
 
       await expectLater(
         api.geocodeMultiple('nowhere'),
+        throwsA(isA<GeocodingNotFoundException>()),
+      );
+    });
+
+    test('throws GeocodingNotFoundException when array is empty', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(200, '[]'));
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.geocodeMultiple('Fresno, CA'),
         throwsA(isA<GeocodingNotFoundException>()),
       );
     });
@@ -113,16 +143,6 @@ void main() {
       await expectLater(
         api.geocodeMultiple('Fresno, CA'),
         throwsA(isA<GeocodingException>()),
-      );
-    });
-
-    test('throws GeocodingNotFoundException when array is empty', () async {
-      final GeocodingApi api = _makeApi(mockClientReturning(200, '[]'));
-      addTearDown(api.dispose);
-
-      await expectLater(
-        api.geocodeMultiple('Fresno, CA'),
-        throwsA(isA<GeocodingNotFoundException>()),
       );
     });
 

--- a/test/geocoding_api_test.dart
+++ b/test/geocoding_api_test.dart
@@ -220,6 +220,97 @@ void main() {
   });
 
   // -------------------------------------------------------------------------
+  // autocomplete
+  // -------------------------------------------------------------------------
+
+  group('GeocodingApi.autocomplete', () {
+    test('returns results on 200', () async {
+      final GeocodingApi api = _makeApi(
+        mockClientReturning(200, _validBodyWithState),
+      );
+      addTearDown(api.dispose);
+      final List<GeocodingResult> results = await api.autocomplete('Fres');
+
+      expect(results, hasLength(1));
+      expect(results.first.displayName, 'Fresno, California, US');
+    });
+
+    test('throws GeocodingNotFoundException on 404', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(404, 'not found'));
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.autocomplete('xyzzy'),
+        throwsA(isA<GeocodingNotFoundException>()),
+      );
+    });
+
+    test('throws GeocodingNotFoundException when array is empty', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(200, '[]'));
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.autocomplete('xyzzy'),
+        throwsA(isA<GeocodingNotFoundException>()),
+      );
+    });
+
+    test('throws GeocodingException on 500', () async {
+      final GeocodingApi api = _makeApi(mockClientReturning(500, 'error'));
+      addTearDown(api.dispose);
+
+      await expectLater(
+        api.autocomplete('Fres'),
+        throwsA(isA<GeocodingException>()),
+      );
+    });
+
+    test(
+      'throws GeocodingException when all items have missing required fields',
+      () async {
+        final GeocodingApi api = _makeApi(
+          mockClientReturning(200, '[{"lat":36.75,"lon":-119.65}]'),
+        );
+        addTearDown(api.dispose);
+
+        await expectLater(
+          api.autocomplete('Fres'),
+          throwsA(isA<GeocodingException>()),
+        );
+      },
+    );
+
+    test('sends query as q parameter', () async {
+      Uri? captured;
+      final MockClient client = MockClient((http.Request req) async {
+        captured = req.url;
+        return http.Response(_validBodyWithState, 200);
+      });
+
+      final GeocodingApi api = _makeApi(client);
+      addTearDown(api.dispose);
+      await api.autocomplete('Fres');
+
+      expect(captured?.path, '/api/autocomplete');
+      expect(captured?.queryParameters['q'], 'Fres');
+    });
+
+    test('sends X-Device-ID header', () async {
+      Map<String, String>? capturedHeaders;
+      final MockClient client = MockClient((http.Request req) async {
+        capturedHeaders = req.headers;
+        return http.Response(_validBodyWithState, 200);
+      });
+
+      final GeocodingApi api = _makeApi(client);
+      addTearDown(api.dispose);
+      await api.autocomplete('Fres');
+
+      expect(capturedHeaders?[deviceIdHeader], 'test-device-id');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // reverseGeocode
   // -------------------------------------------------------------------------
 

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -7,6 +7,27 @@ import 'package:uvalert/constants.dart';
 http.Client mockClientReturning(int status, [String body = '']) =>
     MockClient((_) async => http.Response(body, status));
 
+/// Returns a [MockClient] that dispatches by path and query parameter:
+/// - `/api/autocomplete?q=` → [autocompleteStatus]/[autocompleteBody]
+/// - `/api/geocode?q=`      → [forwardStatus]/[forwardBody]
+/// - `/api/geocode?lat=`    → [reverseStatus]/[reverseBody]
+http.Client mockClientByQuery({
+  int forwardStatus = 200,
+  String forwardBody = '',
+  int reverseStatus = 200,
+  String reverseBody = '',
+  int autocompleteStatus = 200,
+  String? autocompleteBody,
+}) => MockClient((http.Request req) async {
+  if (req.url.path.contains('autocomplete')) {
+    return http.Response(autocompleteBody ?? forwardBody, autocompleteStatus);
+  }
+  if (req.url.queryParameters.containsKey('q')) {
+    return http.Response(forwardBody, forwardStatus);
+  }
+  return http.Response(reverseBody, reverseStatus);
+});
+
 // 100 ms past the 2-second minimum splash floor in OnboardingScreen.
 const Duration _splashClearDelay = Duration(milliseconds: 2100);
 

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -37,6 +37,18 @@ const Duration gpsOvershoot = Duration(milliseconds: 100);
 /// Extra buffer added to [gpsTimeout] for the per-test [Timeout] annotation.
 const Duration gpsTestBuffer = Duration(seconds: 5);
 
+/// Duration past the autocomplete debounce window; enough for the timer to
+/// fire and the async geocode to complete before the next pump.
+const Duration debounceFired = Duration(milliseconds: 500);
+
+/// Duration within the debounce window; a pump this short must not trigger
+/// autocomplete.
+const Duration withinDebounce = Duration(milliseconds: 200);
+
+/// Remaining debounce time after two [withinDebounce] pumps; ensures the
+/// timer fires on the third pump.
+const Duration debounceRemainder = Duration(milliseconds: 300);
+
 /// Pumps the splash screen and settles all resulting navigation animations.
 ///
 /// Pass [hasSplashFloor]: true (default) when the test triggers the 2-second

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -17,10 +17,10 @@ http.Client mockClientByQuery({
   int reverseStatus = 200,
   String reverseBody = '',
   int autocompleteStatus = 200,
-  String? autocompleteBody,
+  String autocompleteBody = '',
 }) => MockClient((http.Request req) async {
   if (req.url.path == '/api/autocomplete') {
-    return http.Response(autocompleteBody ?? forwardBody, autocompleteStatus);
+    return http.Response(autocompleteBody, autocompleteStatus);
   }
   if (req.url.queryParameters.containsKey('q')) {
     return http.Response(forwardBody, forwardStatus);

--- a/test/helpers.dart
+++ b/test/helpers.dart
@@ -19,7 +19,7 @@ http.Client mockClientByQuery({
   int autocompleteStatus = 200,
   String? autocompleteBody,
 }) => MockClient((http.Request req) async {
-  if (req.url.path.contains('autocomplete')) {
+  if (req.url.path == '/api/autocomplete') {
     return http.Response(autocompleteBody ?? forwardBody, autocompleteStatus);
   }
   if (req.url.queryParameters.containsKey('q')) {

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -113,6 +113,20 @@ Future<void> _pumpToPickList(WidgetTester tester) async {
   await tester.pumpAndSettle();
 }
 
+/// Opens the manual-entry field, types [query], fires the debounce, and
+/// settles. Leaves the tester in the state after autocomplete completes.
+Future<void> _pumpToAutocomplete(
+  WidgetTester tester,
+  String query, {
+  Duration delay = debounceFired,
+}) async {
+  await tester.tap(find.text('Enter location manually'));
+  await tester.pump();
+  await tester.enterText(find.byType(TextField), query);
+  await tester.pump(delay);
+  await tester.pumpAndSettle();
+}
+
 /// Drives the screen through manual entry to the confirm phase and taps
 /// Continue. Leaves the tester settled at the post-navigation state.
 Future<void> _tapContinueAfterManualEntry(WidgetTester tester) async {
@@ -841,12 +855,7 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Enter location manually'));
-    await tester.pump();
-
-    await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(debounceFired);
-    await tester.pumpAndSettle();
+    await _pumpToAutocomplete(tester, 'Fres');
 
     // Tap the suggestion.
     await tester.tap(find.text(_displayName));
@@ -871,12 +880,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
-
-      await tester.enterText(find.byType(TextField), 'xyzzy');
-      await tester.pump(debounceFired);
-      await tester.pumpAndSettle();
+      await _pumpToAutocomplete(tester, 'xyzzy');
 
       // No suggestions and no error message shown.
       expect(find.text(_displayName), findsNothing);
@@ -892,12 +896,7 @@ void main() {
       _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
     );
 
-    await tester.tap(find.text('Enter location manually'));
-    await tester.pump();
-
-    await tester.enterText(find.byType(TextField), 'F');
-    await tester.pump(debounceFired);
-    await tester.pumpAndSettle();
+    await _pumpToAutocomplete(tester, 'F');
 
     expect(find.text(_displayName), findsNothing);
   });
@@ -916,13 +915,8 @@ void main() {
       ),
     );
 
-    await tester.tap(find.text('Enter location manually'));
-    await tester.pump();
-
     // Get suggestions showing.
-    await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(debounceFired);
-    await tester.pumpAndSettle();
+    await _pumpToAutocomplete(tester, 'Fres');
     expect(find.text(_displayName), findsOneWidget);
 
     // Type another character - suggestions must clear immediately.

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -65,6 +65,13 @@ const String _multiResultBody =
     '{"lat":42.9,"lon":-81.2,"name":"London",'
     '"country":"CA","state":"Ontario"}]';
 
+// Two Fresno results used by separator rendering tests.
+const String _twoFresnoResults =
+    '[{"lat":36.75,"lon":-119.65,'
+    '"name":"Fresno","state":"California","country":"US"},'
+    '{"lat":34.06,"lon":-117.64,'
+    '"name":"Fresno","state":"Texas","country":"US"}]';
+
 GeocodingApi _fakeGeocodingApi({
   int forwardStatus = 200,
   String forwardBody = _validGeoArray,
@@ -92,6 +99,17 @@ GeocodingApi _fakeGeocodingApi({
 /// Picks the first candidate from the _PickList after a manual search.
 Future<void> _pickFirstCandidate(WidgetTester tester) async {
   await tester.tap(find.text(_displayName));
+  await tester.pumpAndSettle();
+}
+
+/// Drives the screen to the pick-list phase via manual entry of 'London'.
+/// Assumes the widget was pumped with a [GeocodingApi] that returns multiple
+/// results for a forward geocode.
+Future<void> _pumpToPickList(WidgetTester tester) async {
+  await tester.tap(find.text('Enter location manually'));
+  await tester.pump();
+  await tester.enterText(find.byType(TextField), 'London');
+  await tester.testTextInput.receiveAction(TextInputAction.search);
   await tester.pumpAndSettle();
 }
 
@@ -669,11 +687,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
-      await tester.enterText(find.byType(TextField), 'London');
-      await tester.testTextInput.receiveAction(TextInputAction.search);
-      await tester.pumpAndSettle();
+      await _pumpToPickList(tester);
 
       expect(find.text('Select your location:'), findsOneWidget);
       expect(find.text('London, England, GB'), findsOneWidget);
@@ -692,11 +706,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
-      await tester.enterText(find.byType(TextField), 'London');
-      await tester.testTextInput.receiveAction(TextInputAction.search);
-      await tester.pumpAndSettle();
+      await _pumpToPickList(tester);
 
       await tester.tap(find.text('London, England, GB'));
       await tester.pumpAndSettle();
@@ -717,11 +727,7 @@ void main() {
         ),
       );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
-      await tester.enterText(find.byType(TextField), 'London');
-      await tester.testTextInput.receiveAction(TextInputAction.search);
-      await tester.pumpAndSettle();
+      await _pumpToPickList(tester);
 
       await tester.ensureVisible(find.text('Search again'));
       await tester.tap(find.text('Search again'));
@@ -1032,18 +1038,12 @@ void main() {
   testWidgets(
     'autocomplete with multiple results renders suggestion separators',
     (WidgetTester tester) async {
-      const String twoResults =
-          '[{"lat":36.75,"lon":-119.65,'
-          '"name":"Fresno","state":"California","country":"US"},'
-          '{"lat":34.06,"lon":-117.64,'
-          '"name":"Fresno","state":"Texas","country":"US"}]';
-
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
             geocodingApi: _fakeGeocodingApi(
               autocompleteStatus: 200,
-              autocompleteBody: twoResults,
+              autocompleteBody: _twoFresnoResults,
             ),
           ),
         ),
@@ -1068,16 +1068,10 @@ void main() {
   testWidgets(
     'pick list with multiple candidates renders separators',
     (WidgetTester tester) async {
-      const String twoResults =
-          '[{"lat":36.75,"lon":-119.65,'
-          '"name":"Fresno","state":"California","country":"US"},'
-          '{"lat":34.06,"lon":-117.64,'
-          '"name":"Fresno","state":"Texas","country":"US"}]';
-
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: twoResults),
+            geocodingApi: _fakeGeocodingApi(forwardBody: _twoFresnoResults),
           ),
         ),
       );

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -1012,8 +1012,8 @@ void main() {
       _wrap(
         LocationOnboardingScreen(
           geocodingApi: _fakeGeocodingApi(
-            forwardStatus: 500,
-            forwardBody: 'server error',
+            autocompleteStatus: 500,
+            autocompleteBody: 'server error',
           ),
         ),
       ),

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -565,10 +565,7 @@ void main() {
       await tester.pump(gpsTimeout + gpsOvershoot);
       await tester.pumpAndSettle();
 
-      expect(
-        find.textContaining('Could not get a GPS fix'),
-        findsOneWidget,
-      );
+      expect(find.textContaining('Could not get a GPS fix'), findsOneWidget);
     },
     timeout: Timeout(gpsTimeout + gpsTestBuffer),
   );
@@ -873,11 +870,7 @@ void main() {
     'autocomplete 404 silently clears suggestions without showing error',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(),
-          ),
-        ),
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
       );
 
       await _pumpToAutocomplete(tester, 'xyzzy');

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -70,6 +70,10 @@ GeocodingApi _fakeGeocodingApi({
   String forwardBody = _validGeoArray,
   int reverseStatus = 200,
   String reverseBody = _validGeoSingle,
+  // Autocomplete defaults to 404 to avoid suggestions interfering with tests
+  // that use forwardBody for geocodeMultiple only.
+  int autocompleteStatus = 404,
+  String autocompleteBody = 'not found',
 }) {
   return GeocodingApi(
     proxyBaseUrl: _proxyUrl,
@@ -79,6 +83,8 @@ GeocodingApi _fakeGeocodingApi({
       forwardBody: forwardBody,
       reverseStatus: reverseStatus,
       reverseBody: reverseBody,
+      autocompleteStatus: autocompleteStatus,
+      autocompleteBody: autocompleteBody,
     ),
   );
 }
@@ -717,8 +723,9 @@ void main() {
       await tester.testTextInput.receiveAction(TextInputAction.search);
       await tester.pumpAndSettle();
 
+      await tester.ensureVisible(find.text('Search again'));
       await tester.tap(find.text('Search again'));
-      await tester.pumpAndSettle();
+      await tester.pump();
 
       expect(find.byType(TextField), findsOneWidget);
       expect(find.text('Select your location:'), findsNothing);
@@ -762,7 +769,14 @@ void main() {
     'typing shows suggestions after debounce delay fires',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(
+              autocompleteStatus: 200,
+              autocompleteBody: _validGeoArray,
+            ),
+          ),
+        ),
       );
 
       await tester.tap(find.text('Enter location manually'));
@@ -785,7 +799,14 @@ void main() {
     'typing again before debounce fires resets the timer',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(
+              autocompleteStatus: 200,
+              autocompleteBody: _validGeoArray,
+            ),
+          ),
+        ),
       );
 
       await tester.tap(find.text('Enter location manually'));
@@ -814,7 +835,14 @@ void main() {
     'tapping a suggestion from autocomplete goes to confirm phase',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(
+              autocompleteStatus: 200,
+              autocompleteBody: _validGeoArray,
+            ),
+          ),
+        ),
       );
 
       await tester.tap(find.text('Enter location manually'));
@@ -887,7 +915,14 @@ void main() {
     'typing clears existing suggestions immediately',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(
+              autocompleteStatus: 200,
+              autocompleteBody: _validGeoArray,
+            ),
+          ),
+        ),
       );
 
       await tester.tap(find.text('Enter location manually'));
@@ -937,7 +972,11 @@ void main() {
     WidgetTester tester,
   ) async {
     await tester.pumpWidget(
-      _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
+        ),
+      ),
     );
 
     await tester.tap(find.text('Enter location manually'));
@@ -948,6 +987,7 @@ void main() {
     await tester.pumpAndSettle();
 
     // Now in picking phase - tap Search again.
+    await tester.ensureVisible(find.text('Search again'));
     await tester.tap(find.text('Search again'));
     await tester.pump();
 
@@ -1001,7 +1041,10 @@ void main() {
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: twoResults),
+            geocodingApi: _fakeGeocodingApi(
+              autocompleteStatus: 200,
+              autocompleteBody: twoResults,
+            ),
           ),
         ),
       );

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -866,10 +866,7 @@ void main() {
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(
-              forwardStatus: 404,
-              forwardBody: 'not found',
-            ),
+            geocodingApi: _fakeGeocodingApi(),
           ),
         ),
       );

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -644,99 +644,91 @@ void main() {
   // GPS reverseGeocode timeout (inner TimeoutException, lines 144-145)
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'GPS reverseGeocode timeout shows city-not-determined error',
-    (WidgetTester tester) async {
-      final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
-        ..checkResult = LocationPermission.always
-        ..positionResult = fakePosition(lat: 36.75, lon: -119.65);
+  testWidgets('GPS reverseGeocode timeout shows city-not-determined error', (
+    WidgetTester tester,
+  ) async {
+    final FakeGeolocatorPlatform platform = FakeGeolocatorPlatform()
+      ..checkResult = LocationPermission.always
+      ..positionResult = fakePosition(lat: 36.75, lon: -119.65);
 
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _ReverseTimeoutGeocodingApi(),
-          ),
-          platform: platform,
-        ),
-      );
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(geocodingApi: _ReverseTimeoutGeocodingApi()),
+        platform: platform,
+      ),
+    );
 
-      await tester.tap(find.text('Use My Location'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('Use My Location'));
+    await tester.pumpAndSettle();
 
-      expect(
-        find.text(
-          'Could not determine your city. Try entering it manually.',
-        ),
-        findsOneWidget,
-      );
-    },
-  );
+    expect(
+      find.text('Could not determine your city. Try entering it manually.'),
+      findsOneWidget,
+    );
+  });
 
   // -------------------------------------------------------------------------
   // Multiple geocoding results: _Phase.picking (lines 205-208, 358-362, 566+)
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'multiple geocode results shows pick list with all candidates',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
-          ),
+  testWidgets('multiple geocode results shows pick list with all candidates', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
         ),
-      );
+      ),
+    );
 
-      await _pumpToPickList(tester);
+    await _pumpToPickList(tester);
 
-      expect(find.text('Select your location:'), findsOneWidget);
-      expect(find.text('London, England, GB'), findsOneWidget);
-      expect(find.text('London, Ontario, CA'), findsOneWidget);
-    },
-  );
+    expect(find.text('Select your location:'), findsOneWidget);
+    expect(find.text('London, England, GB'), findsOneWidget);
+    expect(find.text('London, Ontario, CA'), findsOneWidget);
+  });
 
-  testWidgets(
-    'picking a candidate from pick list shows confirm card',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
-          ),
+  testWidgets('picking a candidate from pick list shows confirm card', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
         ),
-      );
+      ),
+    );
 
-      await _pumpToPickList(tester);
+    await _pumpToPickList(tester);
 
-      await tester.tap(find.text('London, England, GB'));
-      await tester.pumpAndSettle();
+    await tester.tap(find.text('London, England, GB'));
+    await tester.pumpAndSettle();
 
-      expect(find.text('London, England, GB'), findsOneWidget);
-      expect(find.text('Select your location:'), findsNothing);
-    },
-  );
+    expect(find.text('London, England, GB'), findsOneWidget);
+    expect(find.text('Select your location:'), findsNothing);
+  });
 
-  testWidgets(
-    'tapping Search again from pick list returns to manual entry',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
-          ),
+  testWidgets('tapping Search again from pick list returns to manual entry', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(forwardBody: _multiResultBody),
         ),
-      );
+      ),
+    );
 
-      await _pumpToPickList(tester);
+    await _pumpToPickList(tester);
 
-      await tester.ensureVisible(find.text('Search again'));
-      await tester.tap(find.text('Search again'));
-      await tester.pump();
+    await tester.ensureVisible(find.text('Search again'));
+    await tester.tap(find.text('Search again'));
+    await tester.pump();
 
-      expect(find.byType(TextField), findsOneWidget);
-      expect(find.text('Select your location:'), findsNothing);
-    },
-  );
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.text('Select your location:'), findsNothing);
+  });
 
   // -------------------------------------------------------------------------
 
@@ -771,105 +763,102 @@ void main() {
   // Autocomplete / debounce (onChanged -> _onDebounced)
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'typing shows suggestions after debounce delay fires',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(
-              autocompleteStatus: 200,
-              autocompleteBody: _validGeoArray,
-            ),
+  testWidgets('typing shows suggestions after debounce delay fires', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(
+            autocompleteStatus: 200,
+            autocompleteBody: _validGeoArray,
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      await tester.enterText(find.byType(TextField), 'Fres');
-      // Debounce has not fired yet - suggestions should not appear.
-      await tester.pump();
-      expect(find.text(_displayName), findsNothing);
+    await tester.enterText(find.byType(TextField), 'Fres');
+    // Debounce has not fired yet - suggestions should not appear.
+    await tester.pump();
+    expect(find.text(_displayName), findsNothing);
 
-      // Advance past the 400 ms debounce window and settle the async geocode.
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpAndSettle();
+    // Advance past the 400 ms debounce window and settle the async geocode.
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
 
-      expect(find.text(_displayName), findsOneWidget);
-    },
-  );
+    expect(find.text(_displayName), findsOneWidget);
+  });
 
-  testWidgets(
-    'typing again before debounce fires resets the timer',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(
-              autocompleteStatus: 200,
-              autocompleteBody: _validGeoArray,
-            ),
+  testWidgets('typing again before debounce fires resets the timer', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(
+            autocompleteStatus: 200,
+            autocompleteBody: _validGeoArray,
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      // First keystroke.
-      await tester.enterText(find.byType(TextField), 'Fr');
-      await tester.pump(const Duration(milliseconds: 200));
+    // First keystroke.
+    await tester.enterText(find.byType(TextField), 'Fr');
+    await tester.pump(const Duration(milliseconds: 200));
 
-      // Second keystroke before debounce fires.
-      await tester.enterText(find.byType(TextField), 'Fres');
-      await tester.pump(const Duration(milliseconds: 200));
+    // Second keystroke before debounce fires.
+    await tester.enterText(find.byType(TextField), 'Fres');
+    await tester.pump(const Duration(milliseconds: 200));
 
-      // Still within debounce window from second keystroke - no suggestions.
-      expect(find.text(_displayName), findsNothing);
+    // Still within debounce window from second keystroke - no suggestions.
+    expect(find.text(_displayName), findsNothing);
 
-      // Now let the debounce fire and the geocode settle.
-      await tester.pump(const Duration(milliseconds: 300));
-      await tester.pumpAndSettle();
+    // Now let the debounce fire and the geocode settle.
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pumpAndSettle();
 
-      expect(find.text(_displayName), findsOneWidget);
-    },
-  );
+    expect(find.text(_displayName), findsOneWidget);
+  });
 
-  testWidgets(
-    'tapping a suggestion from autocomplete goes to confirm phase',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(
-              autocompleteStatus: 200,
-              autocompleteBody: _validGeoArray,
-            ),
+  testWidgets('tapping a suggestion from autocomplete goes to confirm phase', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(
+            autocompleteStatus: 200,
+            autocompleteBody: _validGeoArray,
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      await tester.enterText(find.byType(TextField), 'Fres');
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Fres');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
 
-      // Tap the suggestion.
-      await tester.tap(find.text(_displayName));
-      await tester.pumpAndSettle();
+    // Tap the suggestion.
+    await tester.tap(find.text(_displayName));
+    await tester.pumpAndSettle();
 
-      // Should now be in confirm phase: display name shown, Continue enabled.
-      expect(find.text(_displayName), findsOneWidget);
-      final FilledButton btn = tester.widget<FilledButton>(
-        find.widgetWithText(FilledButton, 'Continue'),
-      );
-      expect(btn.onPressed, isNotNull);
-    },
-  );
+    // Should now be in confirm phase: display name shown, Continue enabled.
+    expect(find.text(_displayName), findsOneWidget);
+    final FilledButton btn = tester.widget<FilledButton>(
+      find.widgetWithText(FilledButton, 'Continue'),
+    );
+    expect(btn.onPressed, isNotNull);
+  });
 
   testWidgets(
     'autocomplete 404 silently clears suggestions without showing error',
@@ -899,53 +888,51 @@ void main() {
     },
   );
 
-  testWidgets(
-    'typing fewer than 2 chars does not trigger autocomplete',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
-      );
+  testWidgets('typing fewer than 2 chars does not trigger autocomplete', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      await tester.enterText(find.byType(TextField), 'F');
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'F');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
 
-      expect(find.text(_displayName), findsNothing);
-    },
-  );
+    expect(find.text(_displayName), findsNothing);
+  });
 
-  testWidgets(
-    'typing clears existing suggestions immediately',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(
-              autocompleteStatus: 200,
-              autocompleteBody: _validGeoArray,
-            ),
+  testWidgets('typing clears existing suggestions immediately', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(
+            autocompleteStatus: 200,
+            autocompleteBody: _validGeoArray,
           ),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      // Get suggestions showing.
-      await tester.enterText(find.byType(TextField), 'Fres');
-      await tester.pump(const Duration(milliseconds: 500));
-      await tester.pumpAndSettle();
-      expect(find.text(_displayName), findsOneWidget);
+    // Get suggestions showing.
+    await tester.enterText(find.byType(TextField), 'Fres');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+    expect(find.text(_displayName), findsOneWidget);
 
-      // Type another character - suggestions must clear immediately.
-      await tester.enterText(find.byType(TextField), 'Fresn');
-      await tester.pump();
-      expect(find.text(_displayName), findsNothing);
-    },
-  );
+    // Type another character - suggestions must clear immediately.
+    await tester.enterText(find.byType(TextField), 'Fresn');
+    await tester.pump();
+    expect(find.text(_displayName), findsNothing);
+  });
   // -------------------------------------------------------------------------
   // _onBack via AppBar back button (lines 342-350)
   // -------------------------------------------------------------------------
@@ -1065,29 +1052,28 @@ void main() {
   // _PickList separator (line 673) — needs 2+ candidates from geocodeMultiple
   // -------------------------------------------------------------------------
 
-  testWidgets(
-    'pick list with multiple candidates renders separators',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        _wrap(
-          LocationOnboardingScreen(
-            geocodingApi: _fakeGeocodingApi(forwardBody: _twoFresnoResults),
-          ),
+  testWidgets('pick list with multiple candidates renders separators', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(forwardBody: _twoFresnoResults),
         ),
-      );
+      ),
+    );
 
-      await tester.tap(find.text('Enter location manually'));
-      await tester.pump();
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
 
-      await tester.enterText(find.byType(TextField), 'Fresno, CA');
-      await tester.testTextInput.receiveAction(TextInputAction.search);
-      await tester.pumpAndSettle();
+    await tester.enterText(find.byType(TextField), 'Fresno, CA');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
 
-      expect(find.text('Fresno, California, US'), findsOneWidget);
-      expect(find.text('Fresno, Texas, US'), findsOneWidget);
-      expect(find.text('Search again'), findsOneWidget);
-    },
-  );
+    expect(find.text('Fresno, California, US'), findsOneWidget);
+    expect(find.text('Fresno, Texas, US'), findsOneWidget);
+    expect(find.text('Search again'), findsOneWidget);
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1110,17 +1096,13 @@ class _SlowGeolocatorPlatform extends FakeGeolocatorPlatform {
 
 class _ReverseTimeoutGeocodingApi extends GeocodingApi {
   _ReverseTimeoutGeocodingApi()
-    : super(
-        proxyBaseUrl: _proxyUrl,
-        deviceId: 'test-device-id',
-      );
+    : super(proxyBaseUrl: _proxyUrl, deviceId: 'test-device-id');
 
   @override
   Future<GeocodingResult> reverseGeocode({
     required double lat,
     required double lon,
-  }) =>
-      Future<GeocodingResult>.error(
-        TimeoutException('reverseGeocode timed out'),
-      );
+  }) => Future<GeocodingResult>.error(
+    TimeoutException('reverseGeocode timed out'),
+  );
 }

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -905,6 +905,152 @@ void main() {
       expect(find.text(_displayName), findsNothing);
     },
   );
+  // -------------------------------------------------------------------------
+  // _onBack via AppBar back button (lines 342-350)
+  // -------------------------------------------------------------------------
+
+  testWidgets('back button from manual phase returns to idle phase', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+    );
+
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
+
+    // Back button is visible while in manual phase.
+    await tester.tap(find.byType(BackButton));
+    await tester.pump();
+
+    // Returned to idle: both option buttons visible again.
+    expect(find.text('Use My Location'), findsOneWidget);
+    expect(find.text('Enter location manually'), findsOneWidget);
+    expect(find.byType(TextField), findsNothing);
+  });
+
+  // -------------------------------------------------------------------------
+  // _onSearchAgain via Search again button in _PickList (lines 265-273)
+  // -------------------------------------------------------------------------
+
+  testWidgets('Search again from pick list returns to manual entry', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+    );
+
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'Fresno, CA');
+    await tester.testTextInput.receiveAction(TextInputAction.search);
+    await tester.pumpAndSettle();
+
+    // Now in picking phase - tap Search again.
+    await tester.tap(find.text('Search again'));
+    await tester.pump();
+
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.text('Search again'), findsNothing);
+  });
+
+  // -------------------------------------------------------------------------
+  // Autocomplete generic error (lines 208-210 in _onDebounced)
+  // -------------------------------------------------------------------------
+
+  testWidgets('autocomplete generic error silently clears suggestions', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(
+        LocationOnboardingScreen(
+          geocodingApi: _fakeGeocodingApi(
+            forwardStatus: 500,
+            forwardBody: 'server error',
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Enter location manually'));
+    await tester.pump();
+
+    await tester.enterText(find.byType(TextField), 'Fres');
+    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pumpAndSettle();
+
+    // No suggestions and no error banner shown for autocomplete failures.
+    expect(find.text(_displayName), findsNothing);
+    expect(find.textContaining('Something went wrong'), findsNothing);
+  });
+
+  // -------------------------------------------------------------------------
+  // _SuggestionList separator (line 706) — needs 2+ suggestions
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'autocomplete with multiple results renders suggestion separators',
+    (WidgetTester tester) async {
+      const String twoResults =
+          '[{"lat":36.75,"lon":-119.65,'
+          '"name":"Fresno","state":"California","country":"US"},'
+          '{"lat":34.06,"lon":-117.64,'
+          '"name":"Fresno","state":"Texas","country":"US"}]';
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(forwardBody: twoResults),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'Fres');
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Fresno, California, US'), findsOneWidget);
+      expect(find.text('Fresno, Texas, US'), findsOneWidget);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // _PickList separator (line 673) — needs 2+ candidates from geocodeMultiple
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'pick list with multiple candidates renders separators',
+    (WidgetTester tester) async {
+      const String twoResults =
+          '[{"lat":36.75,"lon":-119.65,'
+          '"name":"Fresno","state":"California","country":"US"},'
+          '{"lat":34.06,"lon":-117.64,'
+          '"name":"Fresno","state":"Texas","country":"US"}]';
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(forwardBody: twoResults),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'Fresno, CA');
+      await tester.testTextInput.receiveAction(TextInputAction.search);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Fresno, California, US'), findsOneWidget);
+      expect(find.text('Fresno, Texas, US'), findsOneWidget);
+      expect(find.text('Search again'), findsOneWidget);
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -552,7 +552,7 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(
-        find.textContaining('GPS is not available on this device'),
+        find.textContaining('Could not get a GPS fix'),
         findsOneWidget,
       );
     },
@@ -786,7 +786,7 @@ void main() {
     expect(find.text(_displayName), findsNothing);
 
     // Advance past the 400 ms debounce window and settle the async geocode.
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(debounceFired);
     await tester.pumpAndSettle();
 
     expect(find.text(_displayName), findsOneWidget);
@@ -811,17 +811,17 @@ void main() {
 
     // First keystroke.
     await tester.enterText(find.byType(TextField), 'Fr');
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(withinDebounce);
 
     // Second keystroke before debounce fires.
     await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(const Duration(milliseconds: 200));
+    await tester.pump(withinDebounce);
 
     // Still within debounce window from second keystroke - no suggestions.
     expect(find.text(_displayName), findsNothing);
 
     // Now let the debounce fire and the geocode settle.
-    await tester.pump(const Duration(milliseconds: 300));
+    await tester.pump(debounceRemainder);
     await tester.pumpAndSettle();
 
     expect(find.text(_displayName), findsOneWidget);
@@ -845,7 +845,7 @@ void main() {
     await tester.pump();
 
     await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(debounceFired);
     await tester.pumpAndSettle();
 
     // Tap the suggestion.
@@ -878,7 +878,7 @@ void main() {
       await tester.pump();
 
       await tester.enterText(find.byType(TextField), 'xyzzy');
-      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(debounceFired);
       await tester.pumpAndSettle();
 
       // No suggestions and no error message shown.
@@ -899,7 +899,7 @@ void main() {
     await tester.pump();
 
     await tester.enterText(find.byType(TextField), 'F');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(debounceFired);
     await tester.pumpAndSettle();
 
     expect(find.text(_displayName), findsNothing);
@@ -924,7 +924,7 @@ void main() {
 
     // Get suggestions showing.
     await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(debounceFired);
     await tester.pumpAndSettle();
     expect(find.text(_displayName), findsOneWidget);
 
@@ -1010,7 +1010,7 @@ void main() {
     await tester.pump();
 
     await tester.enterText(find.byType(TextField), 'Fres');
-    await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(debounceFired);
     await tester.pumpAndSettle();
 
     // No suggestions and no error banner shown for autocomplete failures.
@@ -1040,7 +1040,7 @@ void main() {
       await tester.pump();
 
       await tester.enterText(find.byType(TextField), 'Fres');
-      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pump(debounceFired);
       await tester.pumpAndSettle();
 
       expect(find.text('Fresno, California, US'), findsOneWidget);

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -4,8 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:geolocator/geolocator.dart';
-import 'package:http/http.dart' as http;
-import 'package:http/testing.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/api/geocoding_api.dart';
 import 'package:uvalert/constants.dart';
@@ -49,16 +47,14 @@ class _ThrowingSettingsNotifier extends SettingsNotifier {
 
 const String _proxyUrl = 'https://proxy.test';
 
-// displayName assembled as 'name, state, country'.
+// _parseEntry assembles displayName as 'name, state, country'.
 const String _displayName = 'Fresno, California, US';
 
-// geocodeMultiple (forward, ?q=) returns a JSON array.
-const String _validForwardBody =
+// geocodeMultiple expects an array; reverseGeocode expects a single object.
+const String _validGeoArray =
     '[{"lat":36.75,"lon":-119.65,'
     '"name":"Fresno","state":"California","country":"US"}]';
-
-// reverseGeocode (?lat=&lon=) returns a single JSON object.
-const String _validReverseBody =
+const String _validGeoSingle =
     '{"lat":36.75,"lon":-119.65,'
     '"name":"Fresno","state":"California","country":"US"}';
 
@@ -69,23 +65,28 @@ const String _multiResultBody =
     '{"lat":42.9,"lon":-81.2,"name":"London",'
     '"country":"CA","state":"Ontario"}]';
 
-// Routes to array body for forward (?q=) and object body for reverse (?lat=).
-http.Client _geoClient({int status = 200, String? forwardBody}) {
-  final String fwd = forwardBody ?? _validForwardBody;
-  return MockClient((http.Request req) async {
-    if (req.url.queryParameters.containsKey('q')) {
-      return http.Response(fwd, status);
-    }
-    return http.Response(_validReverseBody, status);
-  });
-}
-
-GeocodingApi _fakeGeocodingApi({int status = 200, String? forwardBody}) {
+GeocodingApi _fakeGeocodingApi({
+  int forwardStatus = 200,
+  String forwardBody = _validGeoArray,
+  int reverseStatus = 200,
+  String reverseBody = _validGeoSingle,
+}) {
   return GeocodingApi(
     proxyBaseUrl: _proxyUrl,
     deviceId: 'test-device-id',
-    httpClient: _geoClient(status: status, forwardBody: forwardBody),
+    httpClient: mockClientByQuery(
+      forwardStatus: forwardStatus,
+      forwardBody: forwardBody,
+      reverseStatus: reverseStatus,
+      reverseBody: reverseBody,
+    ),
   );
+}
+
+/// Picks the first candidate from the _PickList after a manual search.
+Future<void> _pickFirstCandidate(WidgetTester tester) async {
+  await tester.tap(find.text(_displayName));
+  await tester.pumpAndSettle();
 }
 
 /// Drives the screen through manual entry to the confirm phase and taps
@@ -96,6 +97,7 @@ Future<void> _tapContinueAfterManualEntry(WidgetTester tester) async {
   await tester.enterText(find.byType(TextField), 'Fresno, CA');
   await tester.testTextInput.receiveAction(TextInputAction.search);
   await tester.pumpAndSettle();
+  await _pickFirstCandidate(tester);
   await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
   await tester.pumpAndSettle();
 }
@@ -209,6 +211,7 @@ void main() {
       await tester.enterText(find.byType(TextField), 'Fresno, CA');
       await tester.testTextInput.receiveAction(TextInputAction.search);
       await tester.pumpAndSettle();
+      await _pickFirstCandidate(tester);
 
       expect(find.text(_displayName), findsOneWidget);
     },
@@ -227,6 +230,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'Fresno, CA');
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
+    await _pickFirstCandidate(tester);
 
     final FilledButton btn = tester.widget<FilledButton>(
       find.widgetWithText(FilledButton, 'Continue'),
@@ -240,7 +244,10 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 404, forwardBody: '[]'),
+          geocodingApi: _fakeGeocodingApi(
+            forwardStatus: 404,
+            forwardBody: 'not found',
+          ),
         ),
       ),
     );
@@ -262,7 +269,10 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 500, forwardBody: 'error'),
+          geocodingApi: _fakeGeocodingApi(
+            forwardStatus: 500,
+            forwardBody: 'error',
+          ),
         ),
       ),
     );
@@ -294,6 +304,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'Fresno, CA');
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
+    await _pickFirstCandidate(tester);
 
     await tester.tap(find.text('Change'));
     await tester.pump();
@@ -375,7 +386,10 @@ void main() {
     await tester.pumpWidget(
       _wrap(
         LocationOnboardingScreen(
-          geocodingApi: _fakeGeocodingApi(status: 404, forwardBody: '[]'),
+          geocodingApi: _fakeGeocodingApi(
+            reverseStatus: 404,
+            reverseBody: 'not found',
+          ),
         ),
         platform: platform,
       ),
@@ -566,6 +580,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'Fresno, CA');
     await tester.tap(find.byIcon(Icons.search));
     await tester.pumpAndSettle();
+    await _pickFirstCandidate(tester);
 
     expect(find.text(_displayName), findsOneWidget);
   });
@@ -589,6 +604,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'Fresno, CA');
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
+    await _pickFirstCandidate(tester);
 
     await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
     await tester.pumpAndSettle();
@@ -726,6 +742,7 @@ void main() {
     await tester.enterText(find.byType(TextField), 'Fresno, CA');
     await tester.testTextInput.receiveAction(TextInputAction.search);
     await tester.pumpAndSettle();
+    await _pickFirstCandidate(tester);
 
     await tester.tap(find.widgetWithText(FilledButton, 'Continue'));
     await tester.pumpAndSettle();
@@ -736,6 +753,158 @@ void main() {
     );
     expect(btn.onPressed, isNotNull);
   });
+
+  // -------------------------------------------------------------------------
+  // Autocomplete / debounce (onChanged -> _onDebounced)
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'typing shows suggestions after debounce delay fires',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'Fres');
+      // Debounce has not fired yet - suggestions should not appear.
+      await tester.pump();
+      expect(find.text(_displayName), findsNothing);
+
+      // Advance past the 400 ms debounce window and settle the async geocode.
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_displayName), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'typing again before debounce fires resets the timer',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      // First keystroke.
+      await tester.enterText(find.byType(TextField), 'Fr');
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // Second keystroke before debounce fires.
+      await tester.enterText(find.byType(TextField), 'Fres');
+      await tester.pump(const Duration(milliseconds: 200));
+
+      // Still within debounce window from second keystroke - no suggestions.
+      expect(find.text(_displayName), findsNothing);
+
+      // Now let the debounce fire and the geocode settle.
+      await tester.pump(const Duration(milliseconds: 300));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_displayName), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'tapping a suggestion from autocomplete goes to confirm phase',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'Fres');
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      // Tap the suggestion.
+      await tester.tap(find.text(_displayName));
+      await tester.pumpAndSettle();
+
+      // Should now be in confirm phase: display name shown, Continue enabled.
+      expect(find.text(_displayName), findsOneWidget);
+      final FilledButton btn = tester.widget<FilledButton>(
+        find.widgetWithText(FilledButton, 'Continue'),
+      );
+      expect(btn.onPressed, isNotNull);
+    },
+  );
+
+  testWidgets(
+    'autocomplete 404 silently clears suggestions without showing error',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(
+            geocodingApi: _fakeGeocodingApi(
+              forwardStatus: 404,
+              forwardBody: 'not found',
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'xyzzy');
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      // No suggestions and no error message shown.
+      expect(find.text(_displayName), findsNothing);
+      expect(find.textContaining('Location not found'), findsNothing);
+      expect(find.textContaining('Something went wrong'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'typing fewer than 2 chars does not trigger autocomplete',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      await tester.enterText(find.byType(TextField), 'F');
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+
+      expect(find.text(_displayName), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'typing clears existing suggestions immediately',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.text('Enter location manually'));
+      await tester.pump();
+
+      // Get suggestions showing.
+      await tester.enterText(find.byType(TextField), 'Fres');
+      await tester.pump(const Duration(milliseconds: 500));
+      await tester.pumpAndSettle();
+      expect(find.text(_displayName), findsOneWidget);
+
+      // Type another character - suggestions must clear immediately.
+      await tester.enterText(find.byType(TextField), 'Fresn');
+      await tester.pump();
+      expect(find.text(_displayName), findsNothing);
+    },
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -159,8 +159,8 @@ void main() {
               AsyncValue<Preferences>.error(
                 Exception('prefs failed'),
                 StackTrace.empty,
-              )
-            )
+              ),
+            ),
           ],
           child: const MaterialApp(home: NotificationOnboardingScreen()),
         ),


### PR DESCRIPTION
## Summary

- Add `GeocodingApi.autocomplete()` hitting `GET /api/autocomplete?q=` for prefix-matched place suggestions.
- Add `GeocodingApi.geocodeMultiple()` hitting `GET /api/geocode?q=` returning a ranked list of candidates; both share a private `_getResults` helper.
- Update `LocationOnboardingScreen` with debounce-driven autocomplete suggestions, a scrollable pick list for multi-result selection, operation-ID guards on all async paths, and an AppBar back/search-again flow.
- Extend `GeocodingApi` tests to cover multi-result arrays and error-case ordering.
- Extend `LocationOnboardingScreen` tests with autocomplete debounce, suggestion clearing, pick-list selection, and confirm-retry coverage.

## Changes

- `lib/api/geocoding_api.dart` - `autocomplete()`, `geocodeMultiple()`, shared `_getResults()` helper; doc comment updated to cover 200+empty-array case for `GeocodingNotFoundException`.
- `lib/screens/location_onboarding_screen.dart` - debounce timer, `_operationId` invalidation on every keystroke and on manual search, `_debounce?.cancel()` in `_onGeocodeManual`, scrollable `_ResultListView`, `_onChanged` efficiency guard.
- `test/helpers.dart` - `mockClientByQuery` with exact-path dispatch; `autocompleteBody` made non-nullable with `''` default.
- `test/location_onboarding_screen_test.dart` - `_pumpToAutocomplete` helper; autocomplete and pick-list test coverage.
- `pubspec.yaml` - removed unused `fake_async` dev dependency.