### PR TITLE
feat(onboarding): add back navigation across location and notification screens

### DIFF
--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -13,6 +13,7 @@ import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
+import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 // ---------------------------------------------------------------------------
@@ -74,10 +75,20 @@ class LocationOnboardingScreen extends ConsumerStatefulWidget {
   ///
   /// [geocodingApi] is injected for testing; defaults to a real instance
   /// constructed from the stored proxy URL when omitted.
-  const LocationOnboardingScreen({super.key, GeocodingApi? geocodingApi})
-    : _geocodingApi = geocodingApi;
+  ///
+  /// [restoreConfirmedLocation] should be `true` only when navigating back
+  /// from [NotificationOnboardingScreen], so the screen reopens on the
+  /// previously confirmed location instead of the idle picker. Forward
+  /// navigation from [ThemeOnboardingScreen] always leaves it `false`.
+  const LocationOnboardingScreen({
+    super.key,
+    GeocodingApi? geocodingApi,
+    bool restoreConfirmedLocation = false,
+  }) : _geocodingApi = geocodingApi,
+       _restoreConfirmedLocation = restoreConfirmedLocation;
 
   final GeocodingApi? _geocodingApi;
+  final bool _restoreConfirmedLocation;
 
   @override
   ConsumerState<LocationOnboardingScreen> createState() =>
@@ -102,6 +113,36 @@ class _LocationOnboardingScreenState
   final FocusNode _manualFocus = FocusNode();
 
   GeocodingApi? _ownedApi;
+
+  // True once the confirm phase has been restored from persisted settings
+  // (see _restoreConfirmedLocation), so it only happens once even though
+  // settingsProvider/locationProvider are watched (they may still be
+  // resolving on the first build).
+  bool _restoredFromSettings = false;
+
+  // Called only when this screen was opened with
+  // widget._restoreConfirmedLocation set (i.e. navigating back from
+  // NotificationOnboardingScreen). Reconstructs the previously confirmed
+  // location from settingsProvider.manualLocation and locationProvider so the
+  // screen reopens on the confirm card instead of the idle picker. Uses
+  // ref.watch (called from build) rather than ref.read because
+  // settingsProvider may still be loading on the very first build.
+  void _restoreConfirmedLocation() {
+    if (_restoredFromSettings) return;
+
+    final SettingsState? settings = ref.watch(settingsProvider).value;
+    final LocationState location = ref.watch(locationProvider);
+    final String? displayName = settings?.manualLocation;
+
+    if (settings == null || location == null || displayName == null) return;
+
+    _restoredFromSettings = true;
+    _pending = (
+      result: (lat: location.lat, lon: location.lon, displayName: displayName),
+      fromGps: settings.useGps,
+    );
+    _phase = _Phase.confirm;
+  }
 
   GeocodingApi _geocodingApi(String proxyBaseUrl, String deviceId) =>
       widget._geocodingApi ??
@@ -398,6 +439,17 @@ class _LocationOnboardingScreenState
   // -------------------------------------------------------------------------
 
   void _onBack() {
+    if (_phase == _Phase.idle) {
+      unawaited(
+        Navigator.of(context).pushReplacement(
+          MaterialPageRoute<void>(
+            builder: (_) => const ThemeOnboardingScreen(),
+          ),
+        ),
+      );
+      return;
+    }
+
     _debounce?.cancel();
     _operationId++;
     _manualController.clear();
@@ -425,6 +477,8 @@ class _LocationOnboardingScreenState
 
   @override
   Widget build(BuildContext context) {
+    if (widget._restoreConfirmedLocation) _restoreConfirmedLocation();
+
     final String proxyBaseUrl = ref.watch(proxyBaseUrlProvider);
     // Null until deviceIdProvider resolves; callbacks that trigger network
     // calls are disabled while null to prevent an empty X-Device-ID header.
@@ -442,7 +496,7 @@ class _LocationOnboardingScreenState
         ? null
         : (String v) => _onChanged(v, proxyBaseUrl, deviceId);
 
-    final bool canGoBack = _phase != _Phase.idle && _phase != _Phase.loading;
+    final bool canGoBack = _phase != _Phase.loading;
 
     return Scaffold(
       appBar: canGoBack

--- a/lib/screens/location_onboarding_screen.dart
+++ b/lib/screens/location_onboarding_screen.dart
@@ -12,6 +12,7 @@ import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
+import 'package:uvalert/screens/onboarding_back_app_bar.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
 import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
@@ -25,7 +26,6 @@ const double _spinnerSize = 16;
 const double _spinnerStrokeWidth = 2;
 const int _debounceMs = 400;
 const int _minQueryLength = 2;
-const double _appBarElevation = 0;
 
 // ---------------------------------------------------------------------------
 // Confirm result
@@ -477,7 +477,9 @@ class _LocationOnboardingScreenState
 
   @override
   Widget build(BuildContext context) {
-    if (widget._restoreConfirmedLocation) _restoreConfirmedLocation();
+    if (widget._restoreConfirmedLocation && !_restoredFromSettings) {
+      _restoreConfirmedLocation();
+    }
 
     final String proxyBaseUrl = ref.watch(proxyBaseUrlProvider);
     // Null until deviceIdProvider resolves; callbacks that trigger network
@@ -499,13 +501,7 @@ class _LocationOnboardingScreenState
     final bool canGoBack = _phase != _Phase.loading;
 
     return Scaffold(
-      appBar: canGoBack
-          ? AppBar(
-              leading: BackButton(onPressed: _onBack),
-              backgroundColor: Colors.transparent,
-              elevation: _appBarElevation,
-            )
-          : null,
+      appBar: canGoBack ? OnboardingBackAppBar(onBack: _onBack) : null,
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -7,6 +7,7 @@ import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/location_onboarding_screen.dart';
+import 'package:uvalert/screens/onboarding_back_app_bar.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
 import 'package:uvalert/storage/preferences.dart';
 
@@ -14,7 +15,6 @@ import 'package:uvalert/storage/preferences.dart';
 // Layout constants
 // ---------------------------------------------------------------------------
 const int _notificationScreenIndex = totalOnboardingSteps - 1;
-const double _appBarElevation = 0;
 
 // ---------------------------------------------------------------------------
 // Screen
@@ -97,11 +97,7 @@ class _NotificationOnboardingScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: BackButton(onPressed: _continuing ? null : _onBack),
-        backgroundColor: Colors.transparent,
-        elevation: _appBarElevation,
-      ),
+      appBar: OnboardingBackAppBar(onBack: _continuing ? null : _onBack),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(

--- a/lib/screens/notification_onboarding_screen.dart
+++ b/lib/screens/notification_onboarding_screen.dart
@@ -6,6 +6,7 @@ import 'package:uvalert/constants.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/location_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
 import 'package:uvalert/storage/preferences.dart';
 
@@ -13,6 +14,7 @@ import 'package:uvalert/storage/preferences.dart';
 // Layout constants
 // ---------------------------------------------------------------------------
 const int _notificationScreenIndex = totalOnboardingSteps - 1;
+const double _appBarElevation = 0;
 
 // ---------------------------------------------------------------------------
 // Screen
@@ -45,6 +47,17 @@ class _NotificationOnboardingScreenState
   }
 
   int _operationId = 0;
+
+  void _onBack() {
+    unawaited(
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute<void>(
+          builder: (_) =>
+              const LocationOnboardingScreen(restoreConfirmedLocation: true),
+        ),
+      ),
+    );
+  }
 
   Future<void> _advance({required bool notificationsEnabled}) async {
     final int opId = ++_operationId;
@@ -84,6 +97,11 @@ class _NotificationOnboardingScreenState
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(onPressed: _continuing ? null : _onBack),
+        backgroundColor: Colors.transparent,
+        elevation: _appBarElevation,
+      ),
       body: SafeArea(
         child: Padding(
           padding: const EdgeInsets.symmetric(

--- a/lib/screens/onboarding_back_app_bar.dart
+++ b/lib/screens/onboarding_back_app_bar.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+const double _elevation = 0;
+
+/// Transparent, flat AppBar with a back button, shown on onboarding screens
+/// that support navigating to the previous step.
+// Shared between LocationOnboardingScreen and NotificationOnboardingScreen so
+// a single edit keeps both screens visually consistent.
+class OnboardingBackAppBar extends StatelessWidget
+    implements PreferredSizeWidget {
+  /// Creates an [OnboardingBackAppBar].
+  const OnboardingBackAppBar({required this.onBack, super.key});
+
+  /// Called when the back button is tapped; `null` disables the button.
+  final VoidCallback? onBack;
+
+  @override
+  Size get preferredSize => const Size.fromHeight(kToolbarHeight);
+
+  @override
+  Widget build(BuildContext context) {
+    return AppBar(
+      leading: BackButton(onPressed: onBack),
+      backgroundColor: Colors.transparent,
+      elevation: _elevation,
+    );
+  }
+}

--- a/test/fakes/fake_fixed_location_notifier.dart
+++ b/test/fakes/fake_fixed_location_notifier.dart
@@ -1,0 +1,13 @@
+import 'package:uvalert/providers/location_provider.dart';
+
+import 'fake_geolocator.dart';
+
+/// LocationNotifier with a fixed starting lat/lon, mirroring a location that
+/// was already confirmed during a prior visit to LocationOnboardingScreen.
+class FakeFixedLocationNotifier extends LocationNotifier {
+  /// Creates a [FakeFixedLocationNotifier].
+  FakeFixedLocationNotifier() : super(platform: FakeGeolocatorPlatform());
+
+  @override
+  LocationState build() => (lat: 36.75, lon: -119.65);
+}

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -16,6 +16,7 @@ import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
+import 'fakes/fake_fixed_location_notifier.dart';
 import 'fakes/fake_geolocator.dart';
 import 'helpers.dart';
 
@@ -30,19 +31,6 @@ class _NullResultLocationNotifier extends LocationNotifier {
   Future<void> fetchGps() async {
     // Completes without updating state, so locationProvider stays null.
   }
-}
-
-// ---------------------------------------------------------------------------
-// LocationNotifier with a fixed starting lat/lon (covers confirm-phase
-// restore-from-settings, simulating navigating back from
-// NotificationOnboardingScreen after a location was already confirmed).
-// ---------------------------------------------------------------------------
-
-class _FixedLocationNotifier extends LocationNotifier {
-  _FixedLocationNotifier() : super(platform: FakeGeolocatorPlatform());
-
-  @override
-  LocationState build() => (lat: 36.75, lon: -119.65);
 }
 
 // ---------------------------------------------------------------------------
@@ -994,7 +982,7 @@ void main() {
       await tester.pumpWidget(
         _wrap(
           const LocationOnboardingScreen(restoreConfirmedLocation: true),
-          locationFactory: _FixedLocationNotifier.new,
+          locationFactory: FakeFixedLocationNotifier.new,
         ),
       );
       await tester.pumpAndSettle();
@@ -1017,7 +1005,7 @@ void main() {
       await tester.pumpWidget(
         _wrap(
           LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi()),
-          locationFactory: _FixedLocationNotifier.new,
+          locationFactory: FakeFixedLocationNotifier.new,
         ),
       );
       await tester.pumpAndSettle();

--- a/test/location_onboarding_screen_test.dart
+++ b/test/location_onboarding_screen_test.dart
@@ -13,6 +13,7 @@ import 'package:uvalert/providers/settings_provider.dart';
 import 'package:uvalert/providers/uv_provider.dart';
 import 'package:uvalert/screens/location_onboarding_screen.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
+import 'package:uvalert/screens/theme_onboarding_screen.dart';
 import 'package:uvalert/storage/preferences.dart';
 
 import 'fakes/fake_geolocator.dart';
@@ -29,6 +30,19 @@ class _NullResultLocationNotifier extends LocationNotifier {
   Future<void> fetchGps() async {
     // Completes without updating state, so locationProvider stays null.
   }
+}
+
+// ---------------------------------------------------------------------------
+// LocationNotifier with a fixed starting lat/lon (covers confirm-phase
+// restore-from-settings, simulating navigating back from
+// NotificationOnboardingScreen after a location was already confirmed).
+// ---------------------------------------------------------------------------
+
+class _FixedLocationNotifier extends LocationNotifier {
+  _FixedLocationNotifier() : super(platform: FakeGeolocatorPlatform());
+
+  @override
+  LocationState build() => (lat: 36.75, lon: -119.65);
 }
 
 // ---------------------------------------------------------------------------
@@ -940,6 +954,92 @@ void main() {
     expect(find.text('Enter location manually'), findsOneWidget);
     expect(find.byType(TextField), findsNothing);
   });
+
+  testWidgets('back button is shown on the idle phase', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(
+      _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+    );
+    expect(find.byType(BackButton), findsOneWidget);
+  });
+
+  testWidgets(
+    'back button from idle phase navigates to ThemeOnboardingScreen',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi())),
+      );
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ThemeOnboardingScreen), findsOneWidget);
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Restoring confirm phase from settings (back-navigation from
+  // NotificationOnboardingScreen)
+  // -------------------------------------------------------------------------
+
+  testWidgets(
+    'restoreConfirmedLocation: true restores confirm phase from settings',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'uvalert_manual_location': _displayName,
+        'uvalert_use_gps': false,
+      });
+
+      await tester.pumpWidget(
+        _wrap(
+          const LocationOnboardingScreen(restoreConfirmedLocation: true),
+          locationFactory: _FixedLocationNotifier.new,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text(_displayName), findsOneWidget);
+      expect(find.widgetWithText(TextButton, 'Change'), findsOneWidget);
+      expect(find.text('Use My Location'), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'restoreConfirmedLocation: false ignores settings and shows idle picker '
+    'even when a location was previously confirmed',
+    (WidgetTester tester) async {
+      SharedPreferences.setMockInitialValues(<String, Object>{
+        'uvalert_manual_location': _displayName,
+        'uvalert_use_gps': false,
+      });
+
+      await tester.pumpWidget(
+        _wrap(
+          LocationOnboardingScreen(geocodingApi: _fakeGeocodingApi()),
+          locationFactory: _FixedLocationNotifier.new,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Use My Location'), findsOneWidget);
+      expect(find.text('Enter location manually'), findsOneWidget);
+      expect(find.text(_displayName), findsNothing);
+    },
+  );
+
+  testWidgets(
+    'does not restore confirm phase when no location has been confirmed yet',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        _wrap(const LocationOnboardingScreen(restoreConfirmedLocation: true)),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('Use My Location'), findsOneWidget);
+      expect(find.text('Enter location manually'), findsOneWidget);
+    },
+  );
 
   // -------------------------------------------------------------------------
   // _onSearchAgain via Search again button in _PickList (lines 265-273)

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -11,19 +11,7 @@ import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
 import 'package:uvalert/storage/preferences.dart';
 
-import 'fakes/fake_geolocator.dart';
-
-// ---------------------------------------------------------------------------
-// LocationNotifier with a fixed starting lat/lon, mirroring a location that
-// was already confirmed during a prior visit to LocationOnboardingScreen.
-// ---------------------------------------------------------------------------
-
-class _FixedLocationNotifier extends LocationNotifier {
-  _FixedLocationNotifier() : super(platform: FakeGeolocatorPlatform());
-
-  @override
-  LocationState build() => (lat: 36.75, lon: -119.65);
-}
+import 'fakes/fake_fixed_location_notifier.dart';
 
 // ---------------------------------------------------------------------------
 // Widget helper
@@ -188,7 +176,9 @@ void main() {
     await tester.pumpWidget(
       ProviderScope(
         // ignore: always_specify_types (overrides list type not in flutter_riverpod public API)
-        overrides: [locationProvider.overrideWith(_FixedLocationNotifier.new)],
+        overrides: [
+          locationProvider.overrideWith(FakeFixedLocationNotifier.new),
+        ],
         child: const MaterialApp(home: NotificationOnboardingScreen()),
       ),
     );

--- a/test/notification_onboarding_screen_test.dart
+++ b/test/notification_onboarding_screen_test.dart
@@ -3,11 +3,27 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uvalert/constants.dart';
+import 'package:uvalert/providers/location_provider.dart';
 import 'package:uvalert/providers/preferences_provider.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/location_onboarding_screen.dart';
 import 'package:uvalert/screens/notification_onboarding_screen.dart';
 import 'package:uvalert/screens/onboarding_progress_dots.dart';
 import 'package:uvalert/storage/preferences.dart';
+
+import 'fakes/fake_geolocator.dart';
+
+// ---------------------------------------------------------------------------
+// LocationNotifier with a fixed starting lat/lon, mirroring a location that
+// was already confirmed during a prior visit to LocationOnboardingScreen.
+// ---------------------------------------------------------------------------
+
+class _FixedLocationNotifier extends LocationNotifier {
+  _FixedLocationNotifier() : super(platform: FakeGeolocatorPlatform());
+
+  @override
+  LocationState build() => (lat: 36.75, lon: -119.65);
+}
 
 // ---------------------------------------------------------------------------
 // Widget helper
@@ -142,6 +158,46 @@ void main() {
     await tester.pumpAndSettle();
     final Preferences prefs = await Preferences.load();
     expect(prefs.isFirstLaunch, isFalse);
+  });
+
+  // -------------------------------------------------------------------------
+  // Back navigation
+  // -------------------------------------------------------------------------
+
+  testWidgets('shows a back button', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap());
+    expect(find.byType(BackButton), findsOneWidget);
+  });
+
+  testWidgets('tapping back navigates to LocationOnboardingScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap());
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+    expect(find.byType(LocationOnboardingScreen), findsOneWidget);
+  });
+
+  testWidgets('tapping back restores the confirm phase when a location was '
+      'already confirmed', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues(<String, Object>{
+      'uvalert_manual_location': 'Fresno, California, US',
+      'uvalert_use_gps': false,
+    });
+
+    await tester.pumpWidget(
+      ProviderScope(
+        // ignore: always_specify_types (overrides list type not in flutter_riverpod public API)
+        overrides: [locationProvider.overrideWith(_FixedLocationNotifier.new)],
+        child: const MaterialApp(home: NotificationOnboardingScreen()),
+      ),
+    );
+
+    await tester.tap(find.byType(BackButton));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Fresno, California, US'), findsOneWidget);
+    expect(find.widgetWithText(TextButton, 'Change'), findsOneWidget);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a back button to `LocationOnboardingScreen`'s idle phase, navigating to `ThemeOnboardingScreen` (previously the back button was hidden on this phase).
- Add a back button to `NotificationOnboardingScreen`, navigating to `LocationOnboardingScreen`.
- Restore the previously confirmed location (instead of the blank idle picker) when navigating back from `NotificationOnboardingScreen`, via an explicit `restoreConfirmedLocation` constructor flag — not inferred from persisted state, to avoid false-positives on a normal fresh visit with leftover settings from an interrupted prior session.
- Extract a shared `OnboardingBackAppBar` widget used by both screens for visual consistency.
- Add widget test coverage for all of the above, including a shared `FakeFixedLocationNotifier` test fixture.

## Notes

- All onboarding screens navigate via `Navigator.pushReplacement` (no back-stack), so each back button performs an explicit `pushReplacement` to the prior screen rather than a plain pop.
- Verified end-to-end in a live Linux desktop build (idle→Theme back nav, and the confirm-phase restore round trip through Notifications and back).
- Two Copilot review findings about `SafeArea` double-padding under the new AppBars were fact-checked against `Scaffold`'s layout source and found to be false positives (`extendBodyBehindAppBar` is not set, so the body is laid out below the AppBar, not behind it) — resolved with an explanation on the PR.
- Does not resolve any tracked open issue; this is a standalone UX addition on top of already-shipped onboarding screens.