### PR TITLE
feat(dashboard): add app bar with navigation and settings access

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,4 +1,7 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:uvalert/screens/settings_screen.dart';
 
 /// The main screen shown after onboarding completes.
 class DashboardScreen extends StatelessWidget {
@@ -7,6 +10,32 @@ class DashboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('Dashboard')));
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.location_pin),
+          tooltip: 'Change location',
+          onPressed: () {},
+        ),
+        title: const Text('UV Alert'),
+        centerTitle: true,
+        actions: <Widget>[
+          IconButton(
+            icon: const Icon(Icons.settings),
+            tooltip: 'Open settings',
+            onPressed: () {
+              unawaited(
+                Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => const SettingsScreen(),
+                  ),
+                ),
+              );
+            },
+          ),
+        ],
+      ),
+      body: const Center(child: Text('Dashboard')),
+    );
   }
 }

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+/// Placeholder for the settings screen.
+///
+/// Full implementation (location, notifications, support sections) is
+/// tracked in a follow-up issue; see `.private/architecture/SCREENS.md`.
+class SettingsScreen extends StatelessWidget {
+  /// Creates a [SettingsScreen].
+  const SettingsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: const Center(child: Text('Settings')),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 /// Placeholder for the settings screen.
 ///
 /// Full implementation (location, notifications, support sections) is
-/// tracked in a follow-up issue; see `.private/architecture/SCREENS.md`.
+/// tracked in a follow-up issue.
 class SettingsScreen extends StatelessWidget {
   /// Creates a [SettingsScreen].
   const SettingsScreen({super.key});

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -50,6 +50,7 @@ void main() {
     await tester.tap(find.byTooltip('Change location'));
     await tester.pumpAndSettle();
 
-    expect(find.byType(DashboardScreen), findsOneWidget);
+    expect(find.text('Dashboard'), findsOneWidget);
+    expect(find.byType(SettingsScreen), findsNothing);
   });
 }

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -41,4 +41,15 @@ void main() {
 
     expect(find.byType(SettingsScreen), findsOneWidget);
   });
+
+  testWidgets('Tapping the location pin is a no-op', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
+
+    await tester.tap(find.byTooltip('Change location'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(DashboardScreen), findsOneWidget);
+  });
 }

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
+import 'package:uvalert/screens/settings_screen.dart';
 
 void main() {
   testWidgets('DashboardScreen renders Dashboard text', (
@@ -9,5 +10,35 @@ void main() {
     await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
 
     expect(find.text('Dashboard'), findsOneWidget);
+  });
+
+  testWidgets('DashboardScreen app bar has title and both icons', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
+
+    expect(find.text('UV Alert'), findsOneWidget);
+    expect(find.byIcon(Icons.location_pin), findsOneWidget);
+    expect(find.byIcon(Icons.settings), findsOneWidget);
+  });
+
+  testWidgets('DashboardScreen icons expose semantic labels', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
+
+    expect(find.byTooltip('Change location'), findsOneWidget);
+    expect(find.byTooltip('Open settings'), findsOneWidget);
+  });
+
+  testWidgets('Tapping the gear icon opens SettingsScreen', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
+
+    await tester.tap(find.byTooltip('Open settings'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(SettingsScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
- Add an app bar to the dashboard screen for improved navigation.

- Include icons for changing location and accessing settings.

- Implement a placeholder settings screen with basic structure.

- Enhance tests to verify the presence of app bar elements and navigation functionality.