### PR TITLE
feat: implement hourly UV line chart widget

### DIFF
--- a/lib/utils/who_risk.dart
+++ b/lib/utils/who_risk.dart
@@ -71,3 +71,12 @@ Color whoRiskColor(double uvIndex) => whoRiskBand(uvIndex).color;
 
 /// Returns the WHO risk-band label for [uvIndex].
 String whoRiskLabel(double uvIndex) => whoRiskBand(uvIndex).label;
+
+/// The shared "UV index X.X, Y risk" phrase used in accessibility labels
+/// for [uvIndex], so wording stays in sync across widgets that report a
+/// UV reading to screen readers.
+String uvIndexSemanticsPhrase(double uvIndex) {
+  final String uviLabel = truncateToTenth(uvIndex).toStringAsFixed(1);
+  final String risk = whoRiskLabel(uvIndex);
+  return 'UV index $uviLabel, $risk risk';
+}

--- a/lib/utils/who_risk.dart
+++ b/lib/utils/who_risk.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+/// Upper bound (inclusive) of the WHO "Low" UV risk band.
+const double whoLowMax = 2;
+
+/// Upper bound (inclusive) of the WHO "Moderate" UV risk band.
+const double whoModerateMax = 5;
+
+/// Upper bound (inclusive) of the WHO "High" UV risk band.
+const double whoHighMax = 7;
+
+/// Upper bound (inclusive) of the WHO "Very High" UV risk band.
+const double whoVeryHighMax = 10;
+
+// Sourced from WHO's "UV Index Symbol Colour Standards (PMS and RGB)" table,
+// vendored at docs/adr/who-uv-index-colour-standards.pdf: Low RGB(40,149,0)
+// Pantone 375, Moderate RGB(247,228,0) Pantone 102, High RGB(248,89,0)
+// Pantone 151, Very High RGB(216,0,29) Pantone 032, Extreme RGB(107,73,200)
+// Pantone 265.
+
+/// WHO risk-band color for a UV index of 0-2 ("Low").
+const Color whoColorLow = Color(0xFF289500);
+
+/// WHO risk-band color for a UV index of 3-5 ("Moderate").
+const Color whoColorModerate = Color(0xFFF7E400);
+
+/// WHO risk-band color for a UV index of 6-7 ("High").
+const Color whoColorHigh = Color(0xFFF85900);
+
+/// WHO risk-band color for a UV index of 8-10 ("Very High").
+const Color whoColorVeryHigh = Color(0xFFD8001D);
+
+/// WHO risk-band color for a UV index of 11+ ("Extreme").
+const Color whoColorExtreme = Color(0xFF6B49C8);
+
+/// Number of tenths in one whole UV index unit, used to truncate to one
+/// decimal place without rounding.
+const double _tenthsPerUnit = 10;
+
+/// Truncates (not rounds) [uvIndex] to one decimal place, per WHO's
+/// convention of truncating fractional UV readings rather than rounding
+/// them (e.g. 3.01 -> 3.0, 2.99 -> 2.9).
+double truncateToTenth(double uvIndex) =>
+    (uvIndex * _tenthsPerUnit).truncateToDouble() / _tenthsPerUnit;
+
+/// The WHO risk band for a given UV index: its display color and label.
+///
+/// Bands on the same truncated-to-one-decimal value that is displayed, so
+/// the shown number and its color/label can never disagree (e.g. a raw
+/// 5.04 truncates to the displayed "5.0" and bands as Moderate, not High).
+({Color color, String label}) whoRiskBand(double uvIndex) {
+  final double v = truncateToTenth(uvIndex);
+
+  if (v <= whoLowMax) return (color: whoColorLow, label: 'Low');
+
+  if (v <= whoModerateMax) {
+    return (color: whoColorModerate, label: 'Moderate');
+  }
+
+  if (v <= whoHighMax) return (color: whoColorHigh, label: 'High');
+
+  if (v <= whoVeryHighMax) {
+    return (color: whoColorVeryHigh, label: 'Very High');
+  }
+
+  return (color: whoColorExtreme, label: 'Extreme');
+}
+
+/// Returns the WHO risk-band color for [uvIndex].
+Color whoRiskColor(double uvIndex) => whoRiskBand(uvIndex).color;
+
+/// Returns the WHO risk-band label for [uvIndex].
+String whoRiskLabel(double uvIndex) => whoRiskBand(uvIndex).label;

--- a/lib/widgets/uv_current_display.dart
+++ b/lib/widgets/uv_current_display.dart
@@ -39,6 +39,7 @@ class UvCurrentDisplay extends StatelessWidget {
     final Color color = band.color;
     final String risk = band.label;
     final String uviLabel = truncateToTenth(uvIndex).toStringAsFixed(1);
+    final String semanticsLabel = uvIndexSemanticsPhrase(uvIndex);
 
     final TextStyle numberStyle =
         (theme.textTheme.displayLarge ?? const TextStyle(fontSize: 48))
@@ -51,7 +52,7 @@ class UvCurrentDisplay extends StatelessWidget {
     final double strokeWidth = fontSize * _ringStrokeWidthFactor;
 
     return Semantics(
-      label: 'UV index $uviLabel, $risk risk',
+      label: semanticsLabel,
       child: Column(
         mainAxisSize: MainAxisSize.min,
         children: <Widget>[

--- a/lib/widgets/uv_current_display.dart
+++ b/lib/widgets/uv_current_display.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:uvalert/utils/who_risk.dart';
 
 /// Ring stroke width, expressed as a fraction of the UV number's rendered
 /// font size so it scales with font-size accessibility settings instead of
@@ -19,86 +20,6 @@ const double _labelGapFactor = 0.3;
 /// negative sign or an unexpectedly long value).
 const double _ringInnerPaddingFactor = 1.5;
 
-/// Upper bound (inclusive) of the WHO "Low" UV risk band.
-const double _whoLowMax = 2;
-
-/// Upper bound (inclusive) of the WHO "Moderate" UV risk band.
-const double _whoModerateMax = 5;
-
-/// Upper bound (inclusive) of the WHO "High" UV risk band.
-const double _whoHighMax = 7;
-
-/// Upper bound (inclusive) of the WHO "Very High" UV risk band.
-const double _whoVeryHighMax = 10;
-
-// Sourced from WHO's "UV Index Symbol Colour Standards (PMS and RGB)"
-// table, vendored at docs/adr/who-uv-index-colour-standards.pdf: Low
-// RGB(40,149,0) Pantone 375, Moderate RGB(247,228,0) Pantone 102, High
-// RGB(248,89,0) Pantone 151, Very High RGB(216,0,29) Pantone 032,
-// Extreme RGB(107,73,200) Pantone 265.
-
-/// WHO risk-band color for a UV index of 0-2 ("Low").
-const Color _whoColorLow = Color(0xFF289500);
-
-/// WHO risk-band color for a UV index of 3-5 ("Moderate").
-const Color _whoColorModerate = Color(0xFFF7E400);
-
-/// WHO risk-band color for a UV index of 6-7 ("High").
-const Color _whoColorHigh = Color(0xFFF85900);
-
-/// WHO risk-band color for a UV index of 8-10 ("Very High").
-const Color _whoColorVeryHigh = Color(0xFFD8001D);
-
-/// WHO risk-band color for a UV index of 11+ ("Extreme").
-const Color _whoColorExtreme = Color(0xFF6B49C8);
-
-/// Truncates (not rounds) [uvIndex] to one decimal place, per WHO's
-/// convention of truncating fractional UV readings rather than rounding
-/// them (e.g. 3.01 -> 3.0, 2.99 -> 2.9).
-double _truncateToTenth(double uvIndex) =>
-    (uvIndex * _tenthsPerUnit).truncateToDouble() / _tenthsPerUnit;
-
-/// Number of tenths in one whole UV index unit, used to truncate to one
-/// decimal place without rounding.
-const double _tenthsPerUnit = 10;
-
-/// The WHO risk band for a given UV index: its display color and label.
-///
-/// Bands on the same truncated-to-one-decimal value that is displayed, so
-/// the shown number and its color/label can never disagree (e.g. a raw
-/// 5.04 truncates to the displayed "5.0" and bands as Moderate, not High).
-({Color color, String label}) _whoRiskBand(double uvIndex) {
-  final double v = _truncateToTenth(uvIndex);
-
-  if (v <= _whoLowMax) return (color: _whoColorLow, label: 'Low');
-
-  if (v <= _whoModerateMax) {
-    return (color: _whoColorModerate, label: 'Moderate');
-  }
-
-  if (v <= _whoHighMax) return (color: _whoColorHigh, label: 'High');
-
-  if (v <= _whoVeryHighMax) {
-    return (color: _whoColorVeryHigh, label: 'Very High');
-  }
-
-  return (color: _whoColorExtreme, label: 'Extreme');
-}
-
-/// Returns the WHO risk-band color for [uvIndex].
-///
-/// Exposed for tests only; [UvCurrentDisplay] itself reads bands via the
-/// private [_whoRiskBand].
-@visibleForTesting
-Color whoRiskColor(double uvIndex) => _whoRiskBand(uvIndex).color;
-
-/// Returns the WHO risk-band label for [uvIndex].
-///
-/// Exposed for tests only; [UvCurrentDisplay] itself reads bands via the
-/// private [_whoRiskBand].
-@visibleForTesting
-String whoRiskLabel(double uvIndex) => _whoRiskBand(uvIndex).label;
-
 /// The dashboard hero: a large UV index number inside a WHO-colored ring,
 /// with the WHO risk label shown below.
 ///
@@ -114,10 +35,10 @@ class UvCurrentDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final ({Color color, String label}) band = _whoRiskBand(uvIndex);
+    final ({Color color, String label}) band = whoRiskBand(uvIndex);
     final Color color = band.color;
     final String risk = band.label;
-    final String uviLabel = _truncateToTenth(uvIndex).toStringAsFixed(1);
+    final String uviLabel = truncateToTenth(uvIndex).toStringAsFixed(1);
 
     final TextStyle numberStyle =
         (theme.textTheme.displayLarge ?? const TextStyle(fontSize: 48))

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -68,6 +68,18 @@ class UvHourlyChart extends StatelessWidget {
   DateTime _toLocationLocal(DateTime time) =>
       time.add(Duration(seconds: uvData.timezoneOffset));
 
+  /// Builds a [_ChartPoint] for [entry], computing its location-local time
+  /// once and reusing it for both the plotted x-position and the
+  /// accessibility label.
+  _ChartPoint _chartPoint(UvForecastEntry entry, DateTime sunrise) {
+    final DateTime localTime = _toLocationLocal(entry.time);
+    return (
+      hours: localTime.difference(sunrise).inMinutes / Duration.minutesPerHour,
+      localTime: localTime,
+      entry: entry,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final DateTime sunrise = _toLocationLocal(uvData.sunrise);
@@ -79,13 +91,7 @@ class UvHourlyChart extends StatelessWidget {
       for (final UvForecastEntry entry in uvData.hourly)
         if (!entry.time.isBefore(uvData.sunrise) &&
             !entry.time.isAfter(uvData.sunset))
-          (
-            hours:
-                _toLocationLocal(entry.time).difference(sunrise).inMinutes /
-                Duration.minutesPerHour,
-            localTime: _toLocationLocal(entry.time),
-            entry: entry,
-          ),
+          _chartPoint(entry, sunrise),
     ];
 
     return LayoutBuilder(
@@ -129,7 +135,7 @@ class UvHourlyChart extends StatelessWidget {
                       sideTitles: SideTitles(
                         showTitles: true,
                         reservedSize: _leftTitleReservedSize,
-                        interval: whoModerateMax - whoLowMax,
+                        interval: 1,
                         getTitlesWidget: (double value, TitleMeta meta) =>
                             _LeftTitle(value: value, meta: meta),
                       ),
@@ -161,7 +167,15 @@ class UvHourlyChart extends StatelessWidget {
                 ),
               ),
             ),
-            Positioned.fill(child: _HourlyChartSemantics(points: points)),
+            Positioned.fill(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  left: _leftTitleReservedSize,
+                  bottom: _bottomTitleReservedSize,
+                ),
+                child: _HourlyChartSemantics(points: points),
+              ),
+            ),
           ],
         );
       },
@@ -287,6 +301,17 @@ class _BottomTitle extends StatelessWidget {
   }
 }
 
+/// The WHO threshold boundaries drawn on the left axis, matching the
+/// background risk-band edges exactly.
+const List<double> _leftAxisWhoBoundaries = <double>[
+  0,
+  whoLowMax,
+  whoModerateMax,
+  whoHighMax,
+  whoVeryHighMax,
+  _whoExtremeMax,
+];
+
 class _LeftTitle extends StatelessWidget {
   const _LeftTitle({required this.value, required this.meta});
 
@@ -295,6 +320,8 @@ class _LeftTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    if (!_leftAxisWhoBoundaries.contains(value)) return const SizedBox.shrink();
+
     return SideTitleWidget(
       meta: meta,
       child: Text(

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -31,15 +31,29 @@ const double chartYAxisMax = 12;
 /// overlap, so the chart falls back to showing every 2 hours instead.
 const double _minPixelsPerHourLabel = 36;
 
+/// Chart x-axis lower bound: sunrise, 0 hours after itself.
+const double _chartXAxisMin = 0;
+
+/// Chart y-axis lower bound: the minimum possible UV index.
+const double _chartYAxisMin = 0;
+
+/// Left axis tick generation step. Ticks are generated at every whole UV
+/// index unit, then [_isWhoAxisBoundary] filters the rendered labels down
+/// to only the WHO threshold values.
+const double _leftAxisTickInterval = 1;
+
 /// A single hourly UV reading positioned along the chart's x-axis.
 ///
 /// `hours` is the fractional number of hours since sunrise (the chart's
 /// x-coordinate); `localTime` is the reading's timestamp in the queried
-/// location's local time (not the device's).
+/// location's local time (not the device's); `whoColor` is this point's WHO
+/// risk-band color, computed once and reused by the dot painter instead of
+/// re-deriving it per dot paint.
 typedef _ChartPoint = ({
   double hours,
   DateTime localTime,
   UvForecastEntry entry,
+  Color whoColor,
 });
 
 /// A static hourly UV index line chart, spanning sunrise to sunset.
@@ -64,14 +78,15 @@ class UvHourlyChart extends StatelessWidget {
       time.add(Duration(seconds: uvData.timezoneOffset));
 
   /// Builds a [_ChartPoint] for [entry], computing its location-local time
-  /// once and reusing it for both the plotted x-position and the
-  /// accessibility label.
+  /// and WHO risk color once and reusing them for the plotted x-position
+  /// and dot color.
   _ChartPoint _chartPoint(UvForecastEntry entry, DateTime sunrise) {
     final DateTime localTime = _toLocationLocal(entry.time);
     return (
       hours: localTime.difference(sunrise).inSeconds / Duration.secondsPerHour,
       localTime: localTime,
       entry: entry,
+      whoColor: whoRiskColor(entry.uvi),
     );
   }
 
@@ -104,9 +119,9 @@ class UvHourlyChart extends StatelessWidget {
             ExcludeSemantics(
               child: LineChart(
                 LineChartData(
-                  minX: 0,
+                  minX: _chartXAxisMin,
                   maxX: sunsetHours,
-                  minY: 0,
+                  minY: _chartYAxisMin,
                   maxY: chartYAxisMax,
                   backgroundColor: Colors.transparent,
                   gridData: const FlGridData(show: false),
@@ -134,7 +149,7 @@ class UvHourlyChart extends StatelessWidget {
                       sideTitles: SideTitles(
                         showTitles: true,
                         reservedSize: _leftTitleReservedSize,
-                        interval: 1,
+                        interval: _leftAxisTickInterval,
                         getTitlesWidget: (double value, TitleMeta meta) =>
                             _LeftTitle(value: value, meta: meta),
                       ),
@@ -158,7 +173,7 @@ class UvHourlyChart extends StatelessWidget {
                               int index,
                             ) => FlDotCirclePainter(
                               radius: _dotRadius,
-                              color: whoRiskColor(spot.y),
+                              color: points[index].whoColor,
                             ),
                       ),
                     ),
@@ -231,6 +246,10 @@ Duration _hoursDuration(double hours) =>
 /// titles (subtracted from the chart's content area as layout margin), which
 /// is not available for spacing the bottom axis's hour labels.
 double _hourLabelInterval(double plotAreaWidth, double sunsetHours) {
+  // +1 because labels cover both endpoints (0..ceil(sunsetHours) inclusive),
+  // matching fl_chart's own tick count for a fractional axis max -- see
+  // AxisChartHelper.iterateThroughAxis, which always emits an extra tick
+  // exactly at a non-integer max in addition to the integer ticks below it.
   final int hourlyLabelCount = sunsetHours.ceil() + 1;
   final double pixelsPerHour = plotAreaWidth / hourlyLabelCount;
 

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -1,0 +1,306 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:uvalert/models/uv_model.dart';
+import 'package:uvalert/utils/who_risk.dart';
+
+/// Height reserved for the bottom (time) axis titles.
+const double _bottomTitleReservedSize = 28;
+
+/// Height reserved for the left (UV index) axis titles.
+const double _leftTitleReservedSize = 32;
+
+/// Chart line stroke width.
+const double _lineStrokeWidth = 3;
+
+/// Radius of the dot drawn at each data point.
+const double _dotRadius = 2.5;
+
+/// Fixed y-axis upper bound.
+///
+/// The WHO "Extreme" band is open-ended (11+), so the chart caps its
+/// vertical scale here; real-world UV indices essentially never exceed
+/// this in practice.
+const double _yAxisMax = 12;
+
+/// Below this pixel width per hourly label, hour labels would visually
+/// overlap, so the chart falls back to showing every 2 hours instead.
+const double _minPixelsPerHourLabel = 36;
+
+/// Approximate width, in logical pixels, of a single hour-label such as
+/// "2 PM", used to decide whether hourly labels fit without overlapping.
+const double _estimatedHourLabelWidth = 32;
+
+/// The upper bound of the WHO "Extreme" band drawn on the chart background.
+///
+/// The real WHO "Extreme" band is open-ended (11+); the chart draws its
+/// fill up to [_yAxisMax] since that is the top of the visible chart.
+const double _whoExtremeMax = _yAxisMax;
+
+/// A single hourly UV reading positioned along the chart's x-axis.
+///
+/// `hours` is the fractional number of hours since sunrise (the chart's
+/// x-coordinate); `localTime` is the reading's timestamp in the queried
+/// location's local time (not the device's).
+typedef _ChartPoint = ({
+  double hours,
+  DateTime localTime,
+  UvForecastEntry entry,
+});
+
+/// A static hourly UV index line chart, spanning sunrise to sunset.
+///
+/// Draws WHO risk-band background fills, an hourly (or every-2-hours,
+/// if labels would overlap) time axis, and a UV index axis at the WHO
+/// threshold boundaries. Does not support scrub/press interaction -- see
+/// the "Out of scope" note on the originating issue for that follow-up.
+class UvHourlyChart extends StatelessWidget {
+  /// Creates a [UvHourlyChart] from the hourly forecast entries in [uvData]
+  /// that fall between its sunrise and sunset.
+  const UvHourlyChart({required this.uvData, super.key});
+
+  /// The UV data to chart; only [UvData.hourly] entries between
+  /// [UvData.sunrise] and [UvData.sunset] are shown.
+  final UvData uvData;
+
+  /// Converts a UTC [time] to the data's location-local time, using
+  /// [UvData.timezoneOffset] rather than the device's own timezone, so the
+  /// chart reflects the queried location's day rather than the viewer's.
+  DateTime _toLocationLocal(DateTime time) =>
+      time.add(Duration(seconds: uvData.timezoneOffset));
+
+  @override
+  Widget build(BuildContext context) {
+    final DateTime sunrise = _toLocationLocal(uvData.sunrise);
+    final DateTime sunset = _toLocationLocal(uvData.sunset);
+    final double sunsetHours =
+        sunset.difference(sunrise).inMinutes / Duration.minutesPerHour;
+
+    final List<_ChartPoint> points = <_ChartPoint>[
+      for (final UvForecastEntry entry in uvData.hourly)
+        if (!entry.time.isBefore(uvData.sunrise) &&
+            !entry.time.isAfter(uvData.sunset))
+          (
+            hours:
+                _toLocationLocal(entry.time).difference(sunrise).inMinutes /
+                Duration.minutesPerHour,
+            localTime: _toLocationLocal(entry.time),
+            entry: entry,
+          ),
+    ];
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        final double hourInterval = _hourLabelInterval(
+          constraints.maxWidth,
+          sunsetHours,
+        );
+
+        return Stack(
+          children: <Widget>[
+            ExcludeSemantics(
+              child: LineChart(
+                LineChartData(
+                  minX: 0,
+                  maxX: sunsetHours,
+                  minY: 0,
+                  maxY: _yAxisMax,
+                  backgroundColor: Colors.transparent,
+                  gridData: const FlGridData(show: false),
+                  borderData: FlBorderData(show: false),
+                  rangeAnnotations: _whoRangeAnnotations(),
+                  titlesData: FlTitlesData(
+                    topTitles: const AxisTitles(),
+                    rightTitles: const AxisTitles(),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: _bottomTitleReservedSize,
+                        interval: hourInterval,
+                        getTitlesWidget: (double value, TitleMeta meta) =>
+                            _BottomTitle(
+                              label: _formatHour(
+                                sunrise.add(_hoursDuration(value)),
+                              ),
+                              meta: meta,
+                            ),
+                      ),
+                    ),
+                    leftTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: _leftTitleReservedSize,
+                        interval: whoModerateMax - whoLowMax,
+                        getTitlesWidget: (double value, TitleMeta meta) =>
+                            _LeftTitle(value: value, meta: meta),
+                      ),
+                    ),
+                  ),
+                  lineTouchData: const LineTouchData(enabled: false),
+                  lineBarsData: <LineChartBarData>[
+                    LineChartBarData(
+                      spots: <FlSpot>[
+                        for (final _ChartPoint point in points)
+                          FlSpot(point.hours, point.entry.uvi),
+                      ],
+                      barWidth: _lineStrokeWidth,
+                      color: Theme.of(context).colorScheme.onSurface,
+                      dotData: FlDotData(
+                        getDotPainter:
+                            (
+                              FlSpot spot,
+                              double percent,
+                              LineChartBarData bar,
+                              int index,
+                            ) => FlDotCirclePainter(
+                              radius: _dotRadius,
+                              color: whoRiskColor(spot.y),
+                            ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            Positioned.fill(child: _HourlyChartSemantics(points: points)),
+          ],
+        );
+      },
+    );
+  }
+
+  RangeAnnotations _whoRangeAnnotations() => RangeAnnotations(
+    horizontalRangeAnnotations: <HorizontalRangeAnnotation>[
+      HorizontalRangeAnnotation(
+        y1: 0,
+        y2: whoLowMax,
+        color: _bandFill(whoColorLow),
+      ),
+      HorizontalRangeAnnotation(
+        y1: whoLowMax,
+        y2: whoModerateMax,
+        color: _bandFill(whoColorModerate),
+      ),
+      HorizontalRangeAnnotation(
+        y1: whoModerateMax,
+        y2: whoHighMax,
+        color: _bandFill(whoColorHigh),
+      ),
+      HorizontalRangeAnnotation(
+        y1: whoHighMax,
+        y2: whoVeryHighMax,
+        color: _bandFill(whoColorVeryHigh),
+      ),
+      HorizontalRangeAnnotation(
+        y1: whoVeryHighMax,
+        y2: _whoExtremeMax,
+        color: _bandFill(whoColorExtreme),
+      ),
+    ],
+  );
+}
+
+/// Background-fill opacity for WHO risk bands, kept low so the line and
+/// dots remain the visual focus.
+const double _whoBandFillOpacity = 0.12;
+
+Color _bandFill(Color color) => color.withValues(alpha: _whoBandFillOpacity);
+
+Duration _hoursDuration(double hours) =>
+    Duration(seconds: (hours * Duration.secondsPerHour).round());
+
+/// Chooses the hour-label axis interval: every hour, or every 2 hours if
+/// hourly labels would not fit within the available chart width.
+double _hourLabelInterval(double chartWidth, double sunsetHours) {
+  final int hourlyLabelCount = sunsetHours.ceil() + 1;
+  final double pixelsPerHour = chartWidth / hourlyLabelCount;
+
+  final bool hourlyLabelsFit =
+      pixelsPerHour >= _minPixelsPerHourLabel &&
+      pixelsPerHour >= _estimatedHourLabelWidth;
+
+  return hourlyLabelsFit ? 1 : 2;
+}
+
+String _formatHour(DateTime time) => _formatTime(time, includeMinutes: false);
+
+/// Formats [time] as e.g. "2:00 PM" (or "2 PM" when [includeMinutes] is
+/// false), for use in axis labels and accessibility semantic labels.
+String _formatTime(DateTime time, {required bool includeMinutes}) {
+  final int hour24 = time.hour;
+  final int hour12 = hour24 % 12 == 0 ? 12 : hour24 % 12;
+  final String period = hour24 < 12 ? 'AM' : 'PM';
+
+  if (!includeMinutes) return '$hour12 $period';
+
+  final String minutes = time.minute.toString().padLeft(2, '0');
+  return '$hour12:$minutes $period';
+}
+
+/// An invisible, TalkBack-navigable overlay exposing one semantics node per
+/// hourly data point, so screen reader users can swipe through readings
+/// without needing the press-and-hold scrub interaction (out of scope for
+/// this widget; sighted/touch users get only the visual chart).
+class _HourlyChartSemantics extends StatelessWidget {
+  const _HourlyChartSemantics({required this.points});
+
+  final List<_ChartPoint> points;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: Row(
+        children: <Widget>[
+          for (final _ChartPoint point in points)
+            Expanded(
+              child: Semantics(
+                label: _pointLabel(point),
+                child: const SizedBox.expand(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _pointLabel(_ChartPoint point) {
+    final String time = _formatTime(point.localTime, includeMinutes: true);
+    final String uviLabel = truncateToTenth(point.entry.uvi).toStringAsFixed(1);
+    final String risk = whoRiskLabel(point.entry.uvi);
+    return '$time, UV index $uviLabel, $risk risk';
+  }
+}
+
+class _BottomTitle extends StatelessWidget {
+  const _BottomTitle({required this.label, required this.meta});
+
+  final String label;
+  final TitleMeta meta;
+
+  @override
+  Widget build(BuildContext context) {
+    return SideTitleWidget(
+      meta: meta,
+      child: Text(label, style: Theme.of(context).textTheme.bodySmall),
+    );
+  }
+}
+
+class _LeftTitle extends StatelessWidget {
+  const _LeftTitle({required this.value, required this.meta});
+
+  final double value;
+  final TitleMeta meta;
+
+  @override
+  Widget build(BuildContext context) {
+    return SideTitleWidget(
+      meta: meta,
+      child: Text(
+        value.round().toString(),
+        style: Theme.of(context).textTheme.bodySmall,
+      ),
+    );
+  }
+}

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -82,12 +82,15 @@ class UvHourlyChart extends StatelessWidget {
     final double sunsetHours =
         sunset.difference(sunrise).inSeconds / Duration.secondsPerHour;
 
+    // UvData.hourly has no documented ordering guarantee, so sort explicitly
+    // -- an out-of-order list would otherwise draw a zigzagging line and
+    // expose semantics nodes to TalkBack in the wrong swipe order.
     final List<_ChartPoint> points = <_ChartPoint>[
       for (final UvForecastEntry entry in uvData.hourly)
         if (!entry.time.isBefore(uvData.sunrise) &&
             !entry.time.isAfter(uvData.sunset))
           _chartPoint(entry, sunrise),
-    ];
+    ]..sort((_ChartPoint a, _ChartPoint b) => a.hours.compareTo(b.hours));
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -92,7 +92,7 @@ class UvHourlyChart extends StatelessWidget {
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
         final double hourInterval = _hourLabelInterval(
-          constraints.maxWidth,
+          constraints.maxWidth - _leftTitleReservedSize,
           sunsetHours,
         );
 
@@ -222,9 +222,14 @@ Duration _hoursDuration(double hours) =>
 
 /// Chooses the hour-label axis interval: every hour, or every 2 hours if
 /// hourly labels would not fit within the available chart width.
-double _hourLabelInterval(double chartWidth, double sunsetHours) {
+///
+/// [plotAreaWidth] must be the chart's plot area width, not the full widget
+/// width -- fl_chart reserves [_leftTitleReservedSize] for the left axis
+/// titles (subtracted from the chart's content area as layout margin), which
+/// is not available for spacing the bottom axis's hour labels.
+double _hourLabelInterval(double plotAreaWidth, double sunsetHours) {
   final int hourlyLabelCount = sunsetHours.ceil() + 1;
-  final double pixelsPerHour = chartWidth / hourlyLabelCount;
+  final double pixelsPerHour = plotAreaWidth / hourlyLabelCount;
 
   return pixelsPerHour >= _minPixelsPerHourLabel ? 1 : 2;
 }

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -69,7 +69,7 @@ class UvHourlyChart extends StatelessWidget {
   _ChartPoint _chartPoint(UvForecastEntry entry, DateTime sunrise) {
     final DateTime localTime = _toLocationLocal(entry.time);
     return (
-      hours: localTime.difference(sunrise).inMinutes / Duration.minutesPerHour,
+      hours: localTime.difference(sunrise).inSeconds / Duration.secondsPerHour,
       localTime: localTime,
       entry: entry,
     );
@@ -80,7 +80,7 @@ class UvHourlyChart extends StatelessWidget {
     final DateTime sunrise = _toLocationLocal(uvData.sunrise);
     final DateTime sunset = _toLocationLocal(uvData.sunset);
     final double sunsetHours =
-        sunset.difference(sunrise).inMinutes / Duration.minutesPerHour;
+        sunset.difference(sunrise).inSeconds / Duration.secondsPerHour;
 
     final List<_ChartPoint> points = <_ChartPoint>[
       for (final UvForecastEntry entry in uvData.hourly)

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -20,7 +20,15 @@ const double _dotRadius = 2.5;
 /// The WHO "Extreme" band is open-ended (11+), so the chart caps its
 /// vertical scale here; real-world UV indices essentially never exceed
 /// this in practice.
-const double _yAxisMax = 12;
+///
+/// Exposed for tests only; [UvHourlyChart] itself reads this via the
+/// private [_yAxisMax] alias below.
+@visibleForTesting
+const double chartYAxisMax = 12;
+
+/// Private alias for [chartYAxisMax], so production code within this file
+/// reads it under the file's established `_`-prefixed naming convention.
+const double _yAxisMax = chartYAxisMax;
 
 /// Below this pixel width per hourly label, hour labels would visually
 /// overlap, so the chart falls back to showing every 2 hours instead.
@@ -312,6 +320,22 @@ const List<double> _leftAxisWhoBoundaries = <double>[
   _whoExtremeMax,
 ];
 
+/// Tolerance for matching a generated axis tick against
+/// [_leftAxisWhoBoundaries].
+///
+/// fl_chart generates tick values by repeatedly summing the axis interval,
+/// so ticks can accumulate floating-point drift; comparing with a small
+/// tolerance instead of exact equality keeps the boundary labels showing
+/// even if a threshold constant or the axis interval ever becomes a value
+/// that isn't exactly representable in binary floating point.
+const double _axisBoundaryTolerance = 1e-6;
+
+/// Whether [value] matches one of [_leftAxisWhoBoundaries], within
+/// [_axisBoundaryTolerance].
+bool _isWhoAxisBoundary(double value) => _leftAxisWhoBoundaries.any(
+  (double boundary) => (value - boundary).abs() < _axisBoundaryTolerance,
+);
+
 class _LeftTitle extends StatelessWidget {
   const _LeftTitle({required this.value, required this.meta});
 
@@ -320,7 +344,7 @@ class _LeftTitle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (!_leftAxisWhoBoundaries.contains(value)) return const SizedBox.shrink();
+    if (!_isWhoAxisBoundary(value)) return const SizedBox.shrink();
 
     return SideTitleWidget(
       meta: meta,

--- a/lib/widgets/uv_hourly_chart.dart
+++ b/lib/widgets/uv_hourly_chart.dart
@@ -21,28 +21,15 @@ const double _dotRadius = 2.5;
 /// vertical scale here; real-world UV indices essentially never exceed
 /// this in practice.
 ///
-/// Exposed for tests only; [UvHourlyChart] itself reads this via the
-/// private [_yAxisMax] alias below.
+/// Also doubles as the upper bound of the WHO "Extreme" band drawn on the
+/// chart background, since that is the top of the visible chart. Exposed
+/// for tests via [visibleForTesting].
 @visibleForTesting
 const double chartYAxisMax = 12;
-
-/// Private alias for [chartYAxisMax], so production code within this file
-/// reads it under the file's established `_`-prefixed naming convention.
-const double _yAxisMax = chartYAxisMax;
 
 /// Below this pixel width per hourly label, hour labels would visually
 /// overlap, so the chart falls back to showing every 2 hours instead.
 const double _minPixelsPerHourLabel = 36;
-
-/// Approximate width, in logical pixels, of a single hour-label such as
-/// "2 PM", used to decide whether hourly labels fit without overlapping.
-const double _estimatedHourLabelWidth = 32;
-
-/// The upper bound of the WHO "Extreme" band drawn on the chart background.
-///
-/// The real WHO "Extreme" band is open-ended (11+); the chart draws its
-/// fill up to [_yAxisMax] since that is the top of the visible chart.
-const double _whoExtremeMax = _yAxisMax;
 
 /// A single hourly UV reading positioned along the chart's x-axis.
 ///
@@ -117,11 +104,11 @@ class UvHourlyChart extends StatelessWidget {
                   minX: 0,
                   maxX: sunsetHours,
                   minY: 0,
-                  maxY: _yAxisMax,
+                  maxY: chartYAxisMax,
                   backgroundColor: Colors.transparent,
                   gridData: const FlGridData(show: false),
                   borderData: FlBorderData(show: false),
-                  rangeAnnotations: _whoRangeAnnotations(),
+                  rangeAnnotations: _whoRangeAnnotations,
                   titlesData: FlTitlesData(
                     topTitles: const AxisTitles(),
                     rightTitles: const AxisTitles(),
@@ -132,8 +119,9 @@ class UvHourlyChart extends StatelessWidget {
                         interval: hourInterval,
                         getTitlesWidget: (double value, TitleMeta meta) =>
                             _BottomTitle(
-                              label: _formatHour(
+                              label: _formatTime(
                                 sunrise.add(_hoursDuration(value)),
+                                includeMinutes: false,
                               ),
                               meta: meta,
                             ),
@@ -189,37 +177,39 @@ class UvHourlyChart extends StatelessWidget {
       },
     );
   }
-
-  RangeAnnotations _whoRangeAnnotations() => RangeAnnotations(
-    horizontalRangeAnnotations: <HorizontalRangeAnnotation>[
-      HorizontalRangeAnnotation(
-        y1: 0,
-        y2: whoLowMax,
-        color: _bandFill(whoColorLow),
-      ),
-      HorizontalRangeAnnotation(
-        y1: whoLowMax,
-        y2: whoModerateMax,
-        color: _bandFill(whoColorModerate),
-      ),
-      HorizontalRangeAnnotation(
-        y1: whoModerateMax,
-        y2: whoHighMax,
-        color: _bandFill(whoColorHigh),
-      ),
-      HorizontalRangeAnnotation(
-        y1: whoHighMax,
-        y2: whoVeryHighMax,
-        color: _bandFill(whoColorVeryHigh),
-      ),
-      HorizontalRangeAnnotation(
-        y1: whoVeryHighMax,
-        y2: _whoExtremeMax,
-        color: _bandFill(whoColorExtreme),
-      ),
-    ],
-  );
 }
+
+/// WHO risk-band background fills, drawn once and reused across rebuilds
+/// since the boundaries and colors never change.
+final RangeAnnotations _whoRangeAnnotations = RangeAnnotations(
+  horizontalRangeAnnotations: <HorizontalRangeAnnotation>[
+    HorizontalRangeAnnotation(
+      y1: 0,
+      y2: whoLowMax,
+      color: _bandFill(whoColorLow),
+    ),
+    HorizontalRangeAnnotation(
+      y1: whoLowMax,
+      y2: whoModerateMax,
+      color: _bandFill(whoColorModerate),
+    ),
+    HorizontalRangeAnnotation(
+      y1: whoModerateMax,
+      y2: whoHighMax,
+      color: _bandFill(whoColorHigh),
+    ),
+    HorizontalRangeAnnotation(
+      y1: whoHighMax,
+      y2: whoVeryHighMax,
+      color: _bandFill(whoColorVeryHigh),
+    ),
+    HorizontalRangeAnnotation(
+      y1: whoVeryHighMax,
+      y2: chartYAxisMax,
+      color: _bandFill(whoColorExtreme),
+    ),
+  ],
+);
 
 /// Background-fill opacity for WHO risk bands, kept low so the line and
 /// dots remain the visual focus.
@@ -236,14 +226,8 @@ double _hourLabelInterval(double chartWidth, double sunsetHours) {
   final int hourlyLabelCount = sunsetHours.ceil() + 1;
   final double pixelsPerHour = chartWidth / hourlyLabelCount;
 
-  final bool hourlyLabelsFit =
-      pixelsPerHour >= _minPixelsPerHourLabel &&
-      pixelsPerHour >= _estimatedHourLabelWidth;
-
-  return hourlyLabelsFit ? 1 : 2;
+  return pixelsPerHour >= _minPixelsPerHourLabel ? 1 : 2;
 }
-
-String _formatHour(DateTime time) => _formatTime(time, includeMinutes: false);
 
 /// Formats [time] as e.g. "2:00 PM" (or "2 PM" when [includeMinutes] is
 /// false), for use in axis labels and accessibility semantic labels.
@@ -288,9 +272,7 @@ class _HourlyChartSemantics extends StatelessWidget {
 
   String _pointLabel(_ChartPoint point) {
     final String time = _formatTime(point.localTime, includeMinutes: true);
-    final String uviLabel = truncateToTenth(point.entry.uvi).toStringAsFixed(1);
-    final String risk = whoRiskLabel(point.entry.uvi);
-    return '$time, UV index $uviLabel, $risk risk';
+    return '$time, ${uvIndexSemanticsPhrase(point.entry.uvi)}';
   }
 }
 
@@ -317,7 +299,7 @@ const List<double> _leftAxisWhoBoundaries = <double>[
   whoModerateMax,
   whoHighMax,
   whoVeryHighMax,
-  _whoExtremeMax,
+  chartYAxisMax,
 ];
 
 /// Tolerance for matching a generated axis tick against

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   catcher_2: ^2.1.9
   cupertino_icons: ^1.0.8
   device_info_plus: ^13.1.0
+  fl_chart: ^1.2.0
   flutter:
     sdk: flutter
   flutter_local_notifications: ^21.0.0

--- a/test/uv_current_display_test.dart
+++ b/test/uv_current_display_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/utils/who_risk.dart';
 import 'package:uvalert/widgets/uv_current_display.dart';
 
 Widget _wrap(double uvIndex) => MaterialApp(

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -1,0 +1,260 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/models/uv_model.dart';
+import 'package:uvalert/utils/who_risk.dart';
+import 'package:uvalert/widgets/uv_hourly_chart.dart';
+
+import 'fakes/fake_uv_data.dart';
+
+/// Sunrise used by [makeUvData]'s defaults, so hourly fixtures line up.
+final DateTime _sunrise = DateTime.utc(2024, 6, 1, 6);
+
+List<UvForecastEntry> _hourlyFrom(
+  DateTime sunrise,
+  int count, {
+  double Function(int hour)? uviAt,
+}) => <UvForecastEntry>[
+  for (int i = 0; i < count; i++)
+    UvForecastEntry(
+      time: sunrise.add(Duration(hours: i)),
+      uvi: uviAt != null ? uviAt(i) : 5,
+    ),
+];
+
+Widget _wrap(UvData uvData, {double width = 400}) => MaterialApp(
+  home: Scaffold(
+    body: SizedBox(
+      width: width,
+      height: 220,
+      child: UvHourlyChart(uvData: uvData),
+    ),
+  ),
+);
+
+LineChartData _chartData(WidgetTester tester) =>
+    tester.widget<LineChart>(find.byType(LineChart)).data;
+
+void main() {
+  testWidgets('renders a LineChart spanning sunrise to sunset', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(
+      sunrise: _sunrise,
+      sunset: _sunrise.add(const Duration(hours: 14)),
+      hourly: _hourlyFrom(_sunrise, 15),
+    );
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    final LineChartData data = _chartData(tester);
+    expect(data.minX, 0);
+    expect(data.maxX, 14);
+    expect(data.lineBarsData, hasLength(1));
+    expect(data.lineBarsData.single.spots, hasLength(15));
+  });
+
+  testWidgets('only plots hourly entries within sunrise-to-sunset', (
+    WidgetTester tester,
+  ) async {
+    final DateTime sunset = _sunrise.add(const Duration(hours: 14));
+    final UvData uvData = makeUvData(
+      sunrise: _sunrise,
+      sunset: sunset,
+      hourly: <UvForecastEntry>[
+        UvForecastEntry(
+          time: _sunrise.subtract(const Duration(hours: 1)),
+          uvi: 1,
+        ),
+        ..._hourlyFrom(_sunrise, 15),
+        UvForecastEntry(time: sunset.add(const Duration(hours: 1)), uvi: 1),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    expect(_chartData(tester).lineBarsData.single.spots, hasLength(15));
+  });
+
+  group('WHO risk band background fills', () {
+    testWidgets('draws all 5 WHO bands with their reference colors', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 14)),
+        hourly: _hourlyFrom(_sunrise, 15),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final List<HorizontalRangeAnnotation> bands = _chartData(
+        tester,
+      ).rangeAnnotations.horizontalRangeAnnotations;
+
+      expect(bands, hasLength(5));
+
+      final Set<Color> opaqueBandColors = bands
+          .map((HorizontalRangeAnnotation b) => b.color!.withValues(alpha: 1))
+          .toSet();
+
+      expect(
+        opaqueBandColors,
+        containsAll(<Color>[
+          whoColorLow,
+          whoColorModerate,
+          whoColorHigh,
+          whoColorVeryHigh,
+          whoColorExtreme,
+        ]),
+      );
+    });
+
+    testWidgets('bands use a low opacity fill, not a solid color', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 14)),
+        hourly: _hourlyFrom(_sunrise, 15),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final List<HorizontalRangeAnnotation> bands = _chartData(
+        tester,
+      ).rangeAnnotations.horizontalRangeAnnotations;
+
+      for (final HorizontalRangeAnnotation band in bands) {
+        expect(band.color!.a, lessThan(1));
+        expect(band.color!.a, greaterThan(0));
+      }
+    });
+
+    testWidgets('bands span y1/y2 at the WHO threshold boundaries', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 14)),
+        hourly: _hourlyFrom(_sunrise, 15),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final List<HorizontalRangeAnnotation> bands = _chartData(
+        tester,
+      ).rangeAnnotations.horizontalRangeAnnotations;
+
+      final List<double> boundaries = <double>[
+        for (final HorizontalRangeAnnotation b in bands) b.y1,
+        bands.last.y2,
+      ];
+
+      expect(boundaries, <double>[
+        0,
+        whoLowMax,
+        whoModerateMax,
+        whoHighMax,
+        whoVeryHighMax,
+        boundaries.last,
+      ]);
+    });
+  });
+
+  group('hourly vs every-2-hours axis label fallback', () {
+    testWidgets('uses a 1-hour interval when the chart is wide enough', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 6)),
+        hourly: _hourlyFrom(_sunrise, 7),
+      );
+
+      await tester.pumpWidget(_wrap(uvData, width: 800));
+
+      expect(_chartData(tester).titlesData.bottomTitles.sideTitles.interval, 1);
+    });
+
+    testWidgets('falls back to a 2-hour interval on a narrow chart', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 14)),
+        hourly: _hourlyFrom(_sunrise, 15),
+      );
+
+      await tester.pumpWidget(_wrap(uvData, width: 200));
+
+      expect(_chartData(tester).titlesData.bottomTitles.sideTitles.interval, 2);
+    });
+  });
+
+  group('accessibility semantics', () {
+    testWidgets(
+      'exposes one semantics node per hourly point with time, UV, and risk',
+      (WidgetTester tester) async {
+        final UvData uvData = makeUvData(
+          sunrise: _sunrise,
+          sunset: _sunrise.add(const Duration(hours: 2)),
+          hourly: _hourlyFrom(
+            _sunrise,
+            3,
+            uviAt: (int hour) => <double>[1, 4, 9][hour],
+          ),
+        );
+
+        final SemanticsHandle handle = tester.ensureSemantics();
+        await tester.pumpWidget(_wrap(uvData));
+
+        expect(
+          tester.getSemantics(
+            find.bySemanticsLabel(RegExp('6:00 AM, UV index 1.0, Low risk')),
+          ),
+          matchesSemantics(label: '6:00 AM, UV index 1.0, Low risk'),
+        );
+        expect(
+          tester.getSemantics(
+            find.bySemanticsLabel(
+              RegExp('7:00 AM, UV index 4.0, Moderate risk'),
+            ),
+          ),
+          matchesSemantics(label: '7:00 AM, UV index 4.0, Moderate risk'),
+        );
+        expect(
+          tester.getSemantics(
+            find.bySemanticsLabel(
+              RegExp('8:00 AM, UV index 9.0, Very High risk'),
+            ),
+          ),
+          matchesSemantics(label: '8:00 AM, UV index 9.0, Very High risk'),
+        );
+
+        handle.dispose();
+      },
+    );
+
+    testWidgets('excludes the visual chart canvas from the semantics tree', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 2)),
+        hourly: _hourlyFrom(_sunrise, 3),
+      );
+
+      final SemanticsHandle handle = tester.ensureSemantics();
+      await tester.pumpWidget(_wrap(uvData));
+
+      final SemanticsNode chartNode = tester.getSemantics(
+        find.byType(LineChart),
+      );
+      expect(chartNode.label, isEmpty);
+
+      handle.dispose();
+    });
+  });
+}

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -189,7 +189,7 @@ void main() {
         whoModerateMax,
         whoHighMax,
         whoVeryHighMax,
-        boundaries.last,
+        chartYAxisMax,
       ]);
     });
 

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -179,8 +179,8 @@ void main() {
       ).rangeAnnotations.horizontalRangeAnnotations;
 
       final List<double> boundaries = <double>[
-        for (final HorizontalRangeAnnotation b in bands) b.y1,
-        bands.last.y2,
+        bands.first.y1,
+        for (final HorizontalRangeAnnotation b in bands) b.y2,
       ];
 
       expect(boundaries, <double>[

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -36,6 +36,21 @@ Widget _wrap(UvData uvData, {double width = 400}) => MaterialApp(
 LineChartData _chartData(WidgetTester tester) =>
     tester.widget<LineChart>(find.byType(LineChart)).data;
 
+/// A [TitleMeta] fixture for directly invoking a [GetTitleWidgetFunction]
+/// in tests; field values are arbitrary except where the widget under test
+/// reads them.
+TitleMeta _fakeTitleMeta() => TitleMeta(
+  min: 0,
+  max: 12,
+  parentAxisSize: 100,
+  axisPosition: 0,
+  appliedInterval: 1,
+  sideTitles: const SideTitles(),
+  formattedValue: '',
+  axisSide: AxisSide.left,
+  rotationQuarterTurns: 0,
+);
+
 void main() {
   testWidgets('renders a LineChart spanning sunrise to sunset', (
     WidgetTester tester,
@@ -75,6 +90,22 @@ void main() {
     await tester.pumpWidget(_wrap(uvData));
 
     expect(_chartData(tester).lineBarsData.single.spots, hasLength(15));
+  });
+
+  testWidgets('renders without error when hourly is empty', (
+    WidgetTester tester,
+  ) async {
+    // makeUvData()'s hourly default is already an empty list; omitted here
+    // to satisfy the analyzer, but that default is exactly what this test
+    // exercises.
+    final UvData uvData = makeUvData(
+      sunrise: _sunrise,
+      sunset: _sunrise.add(const Duration(hours: 14)),
+    );
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    expect(_chartData(tester).lineBarsData.single.spots, isEmpty);
   });
 
   group('WHO risk band background fills', () {
@@ -161,6 +192,51 @@ void main() {
         boundaries.last,
       ]);
     });
+
+    testWidgets('left axis only labels values at WHO threshold boundaries', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        sunrise: _sunrise,
+        sunset: _sunrise.add(const Duration(hours: 14)),
+        hourly: _hourlyFrom(_sunrise, 15),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final GetTitleWidgetFunction getTitlesWidget = _chartData(
+        tester,
+      ).titlesData.leftTitles.sideTitles.getTitlesWidget;
+      final TitleMeta meta = _fakeTitleMeta();
+
+      Future<bool> hasLabelAt(double value) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: getTitlesWidget(value, meta),
+          ),
+        );
+        return find.byType(Text).evaluate().isNotEmpty;
+      }
+
+      const List<double> whoBoundaries = <double>[0, 2, 5, 7, 10, 12];
+      for (final double value in whoBoundaries) {
+        expect(
+          await hasLabelAt(value),
+          isTrue,
+          reason: 'expected a label at WHO boundary $value',
+        );
+      }
+
+      const List<double> nonBoundaries = <double>[1, 3, 4, 6, 8, 9, 11];
+      for (final double value in nonBoundaries) {
+        expect(
+          await hasLabelAt(value),
+          isFalse,
+          reason: 'expected no label at non-boundary $value',
+        );
+      }
+    });
   });
 
   group('hourly vs every-2-hours axis label fallback', () {
@@ -208,32 +284,34 @@ void main() {
         );
 
         final SemanticsHandle handle = tester.ensureSemantics();
-        await tester.pumpWidget(_wrap(uvData));
+        try {
+          await tester.pumpWidget(_wrap(uvData));
 
-        expect(
-          tester.getSemantics(
-            find.bySemanticsLabel(RegExp('6:00 AM, UV index 1.0, Low risk')),
-          ),
-          matchesSemantics(label: '6:00 AM, UV index 1.0, Low risk'),
-        );
-        expect(
-          tester.getSemantics(
-            find.bySemanticsLabel(
-              RegExp('7:00 AM, UV index 4.0, Moderate risk'),
+          expect(
+            tester.getSemantics(
+              find.bySemanticsLabel(RegExp('6:00 AM, UV index 1.0, Low risk')),
             ),
-          ),
-          matchesSemantics(label: '7:00 AM, UV index 4.0, Moderate risk'),
-        );
-        expect(
-          tester.getSemantics(
-            find.bySemanticsLabel(
-              RegExp('8:00 AM, UV index 9.0, Very High risk'),
+            matchesSemantics(label: '6:00 AM, UV index 1.0, Low risk'),
+          );
+          expect(
+            tester.getSemantics(
+              find.bySemanticsLabel(
+                RegExp('7:00 AM, UV index 4.0, Moderate risk'),
+              ),
             ),
-          ),
-          matchesSemantics(label: '8:00 AM, UV index 9.0, Very High risk'),
-        );
-
-        handle.dispose();
+            matchesSemantics(label: '7:00 AM, UV index 4.0, Moderate risk'),
+          );
+          expect(
+            tester.getSemantics(
+              find.bySemanticsLabel(
+                RegExp('8:00 AM, UV index 9.0, Very High risk'),
+              ),
+            ),
+            matchesSemantics(label: '8:00 AM, UV index 9.0, Very High risk'),
+          );
+        } finally {
+          handle.dispose();
+        }
       },
     );
 
@@ -247,14 +325,16 @@ void main() {
       );
 
       final SemanticsHandle handle = tester.ensureSemantics();
-      await tester.pumpWidget(_wrap(uvData));
+      try {
+        await tester.pumpWidget(_wrap(uvData));
 
-      final SemanticsNode chartNode = tester.getSemantics(
-        find.byType(LineChart),
-      );
-      expect(chartNode.label, isEmpty);
-
-      handle.dispose();
+        final SemanticsNode chartNode = tester.getSemantics(
+          find.byType(LineChart),
+        );
+        expect(chartNode.label, isEmpty);
+      } finally {
+        handle.dispose();
+      }
     });
   });
 }

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -92,6 +92,26 @@ void main() {
     expect(_chartData(tester).lineBarsData.single.spots, hasLength(15));
   });
 
+  testWidgets('plots points in chronological order even if hourly is not', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(
+      sunrise: _sunrise,
+      sunset: _sunrise.add(const Duration(hours: 2)),
+      hourly: <UvForecastEntry>[
+        UvForecastEntry(time: _sunrise.add(const Duration(hours: 2)), uvi: 3),
+        UvForecastEntry(time: _sunrise, uvi: 1),
+        UvForecastEntry(time: _sunrise.add(const Duration(hours: 1)), uvi: 2),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    final List<FlSpot> spots = _chartData(tester).lineBarsData.single.spots;
+    expect(spots.map((FlSpot s) => s.x), <double>[0, 1, 2]);
+    expect(spots.map((FlSpot s) => s.y), <double>[1, 2, 3]);
+  });
+
   testWidgets('renders without error when hourly is empty', (
     WidgetTester tester,
   ) async {

--- a/test/uv_hourly_chart_test.dart
+++ b/test/uv_hourly_chart_test.dart
@@ -219,7 +219,14 @@ void main() {
         return find.byType(Text).evaluate().isNotEmpty;
       }
 
-      const List<double> whoBoundaries = <double>[0, 2, 5, 7, 10, 12];
+      final List<double> whoBoundaries = <double>[
+        0,
+        whoLowMax,
+        whoModerateMax,
+        whoHighMax,
+        whoVeryHighMax,
+        chartYAxisMax,
+      ];
       for (final double value in whoBoundaries) {
         expect(
           await hasLabelAt(value),
@@ -228,7 +235,10 @@ void main() {
         );
       }
 
-      const List<double> nonBoundaries = <double>[1, 3, 4, 6, 8, 9, 11];
+      final List<double> nonBoundaries = <double>[
+        for (int i = 0; i <= chartYAxisMax; i++)
+          if (!whoBoundaries.contains(i.toDouble())) i.toDouble(),
+      ];
       for (final double value in nonBoundaries) {
         expect(
           await hasLabelAt(value),


### PR DESCRIPTION
## Summary

Implements the hourly UV line chart widget (`UvHourlyChart`), spanning sunrise to sunset with WHO risk-band background fills, an hourly (or every-2-hours on narrow screens) time axis, and a UV index axis labeled at the WHO threshold boundaries.

- Extracts shared WHO risk-band logic (thresholds, colors, labels, truncation) out of `UvCurrentDisplay` into a new `lib/utils/who_risk.dart`, so both widgets stay in sync
- X-axis: hourly time labels, falling back to every 2 hours when labels would overlap on narrow screens
- Y-axis: WHO threshold boundaries (0-2 Low, 3-5 Moderate, 6-7 High, 8-10 Very High, >10 Extreme), per the WHO UV Index symbol colour standards (`docs/adr/who-uv-index-colour-standards.pdf`)
- Each hourly point is TalkBack-navigable via an accessibility overlay, with a semantic label of `[time], UV index [value], [risk] risk`
- Static display only -- no scrub/press interaction (tracked separately)
- Full widget test coverage: axis rendering, WHO band fills/boundaries, hourly/2-hour label fallback, accessibility semantics, and point ordering

## Notes

- `UvHourlyChart` is not yet wired into `DashboardScreen` (still a placeholder) -- rendering it on the real dashboard is a follow-up once live UV data is available there.
- WHO axis boundaries were double-checked against the project's vendored WHO colour-standards PDF after a doc/issue mismatch surfaced during review (issue #19's original description stated different cutoffs); issue #19 has been corrected to match the shipped, WHO-table-accurate boundaries.

Fixes #19
