### PR TITLE
feat: add UvDailyChart widget for daily UV index visualization

### DIFF
--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -46,7 +46,8 @@ const List<String> _weekdayAbbreviations = <String>[
 /// `index` is the bar's position (0 = current/earliest day); `localTime` is
 /// the reading's date in the queried location's local time (not the
 /// device's); `whoColor` is this bar's WHO risk-band color, computed once
-/// and reused by both the bar fill and the accessibility label.
+/// and used for the bar fill. The accessibility label derives its own risk
+/// text separately via `whoRiskLabel(entry.uvi)`, not from `whoColor`.
 typedef _ChartPoint = ({
   int index,
   DateTime localTime,

--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -1,0 +1,285 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:uvalert/models/uv_model.dart';
+import 'package:uvalert/utils/who_risk.dart';
+
+/// Number of days shown on the chart, left (current day) to right (last
+/// forecast day).
+const int _daysShown = 7;
+
+/// Fixed y-axis upper bound, matching the hourly chart's cap: the WHO
+/// "Extreme" band is open-ended (11+), and real-world UV indices essentially
+/// never exceed this in practice.
+const double _chartYAxisMax = 12;
+
+/// Chart y-axis lower bound: the minimum possible UV index.
+const double _chartYAxisMin = 0;
+
+/// Width of each bar, kept narrow for tight, clinical spacing per the
+/// Weekly Chart spec.
+const double _barWidth = 20;
+
+/// Radius of the rounded top corners on each bar.
+const double _barTopRadius = 4;
+
+/// Height reserved for the bottom (day-of-week) axis titles.
+const double _bottomTitleReservedSize = 24;
+
+/// Vertical offset from a bar's tip to its UV-value label, so the label
+/// sits just above the bar rather than overlapping it.
+const double _valueLabelOffsetY = -16;
+
+/// Day-of-week abbreviations, indexed by `DateTime.weekday - 1`
+/// (Monday = index 0).
+const List<String> _weekdayAbbreviations = <String>[
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+  'Sun',
+];
+
+/// A single daily UV reading positioned along the chart's x-axis.
+///
+/// `index` is the bar's position (0 = current/earliest day); `localTime` is
+/// the reading's date in the queried location's local time (not the
+/// device's); `whoColor` is this bar's WHO risk-band color, computed once
+/// and reused by both the bar fill and the accessibility label.
+typedef _ChartPoint = ({
+  int index,
+  DateTime localTime,
+  UvForecastEntry entry,
+  Color whoColor,
+});
+
+/// A static 7-day UV index bar chart, current day (left) to last forecast
+/// day (right).
+///
+/// Draws one WHO-colored bar per day with its UV max value labeled on top,
+/// and a day-of-week abbreviation on the bottom axis. Does not highlight
+/// the current day -- its leftmost position conveys that. Does not support
+/// tap/scrub interaction -- see the "Out of scope" note on the originating
+/// issue for that follow-up.
+class UvDailyChart extends StatelessWidget {
+  /// Creates a [UvDailyChart] from up to the first [_daysShown] entries in
+  /// [UvData.daily].
+  const UvDailyChart({required this.uvData, super.key});
+
+  /// The UV data to chart; only the first [_daysShown] entries of
+  /// [UvData.daily], sorted chronologically, are shown.
+  final UvData uvData;
+
+  /// Converts a UTC [time] to the data's location-local time, using
+  /// [UvData.timezoneOffset] rather than the device's own timezone, so the
+  /// chart reflects the queried location's day rather than the viewer's.
+  DateTime _toLocationLocal(DateTime time) =>
+      time.add(Duration(seconds: uvData.timezoneOffset));
+
+  @override
+  Widget build(BuildContext context) {
+    // A cached UvData payload can still be "fresh" (within Cache's 24h TTL)
+    // after its own local calendar day has passed -- e.g. fetched at 11pm,
+    // still valid at 11am the next day. Drop any daily entry whose
+    // location-local date is already in the past so a stale leading day is
+    // never mistaken for "today" by virtue of being the leftmost bar.
+    final DateTime today = _toLocationLocal(DateTime.now().toUtc());
+    // DateTime.utc, not the local-time DateTime() constructor: `today` is
+    // itself UTC-flagged (add() on a UTC DateTime preserves isUtc), and
+    // comparing a UTC-flagged instant against a device-local-flagged one
+    // via isBefore compares absolute instants, not wall-clock fields --
+    // silently shifting this boundary by the device's own UTC offset.
+    final DateTime todayDate = DateTime.utc(today.year, today.month, today.day);
+
+    // UvData.daily has no documented ordering guarantee, so sort explicitly
+    // -- an out-of-order list would otherwise draw days out of sequence and
+    // expose semantics nodes to TalkBack in the wrong swipe order.
+    final List<UvForecastEntry> sorted = <UvForecastEntry>[
+      for (final UvForecastEntry entry in uvData.daily)
+        if (!_toLocationLocal(entry.time).isBefore(todayDate)) entry,
+    ]..sort((UvForecastEntry a, UvForecastEntry b) => a.time.compareTo(b.time));
+
+    final List<_ChartPoint> points = <_ChartPoint>[
+      for (int i = 0; i < sorted.length && i < _daysShown; i++)
+        (
+          index: i,
+          localTime: _toLocationLocal(sorted[i].time),
+          entry: sorted[i],
+          whoColor: whoRiskColor(sorted[i].uvi),
+        ),
+    ];
+
+    final TextStyle? labelStyle = Theme.of(context).textTheme.bodySmall;
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Stack(
+          children: <Widget>[
+            ExcludeSemantics(
+              child: BarChart(
+                BarChartData(
+                  minY: _chartYAxisMin,
+                  maxY: _chartYAxisMax,
+                  // Pinned explicitly (matching the default) rather than
+                  // left implicit, because _DailyChartSemantics._barCenterX
+                  // reimplements this alignment's bar-center formula by
+                  // hand; an upstream default change must not silently
+                  // desync the semantics overlay from the visible bars.
+                  alignment: BarChartAlignment.spaceEvenly,
+                  backgroundColor: Colors.transparent,
+                  gridData: const FlGridData(show: false),
+                  borderData: FlBorderData(show: false),
+                  barTouchData: const BarTouchData(enabled: false),
+                  titlesData: FlTitlesData(
+                    topTitles: const AxisTitles(),
+                    rightTitles: const AxisTitles(),
+                    leftTitles: const AxisTitles(),
+                    bottomTitles: AxisTitles(
+                      sideTitles: SideTitles(
+                        showTitles: true,
+                        reservedSize: _bottomTitleReservedSize,
+                        getTitlesWidget: (double value, TitleMeta meta) {
+                          final int index = value.round();
+                          if (index < 0 || index >= points.length) {
+                            return const SizedBox.shrink();
+                          }
+                          return SideTitleWidget(
+                            meta: meta,
+                            child: Text(
+                              _weekdayAbbreviation(points[index].localTime),
+                              style: labelStyle,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ),
+                  // Exactly one rod per group: _DailyChartSemantics.
+                  // _barCenterX assumes each BarChartGroupData.width equals
+                  // _barWidth exactly, which only holds with a single rod
+                  // (a second rod would add its own width + barsSpace and
+                  // silently desync the semantics overlay from the bars --
+                  // see the class doc on _DailyChartSemantics).
+                  barGroups: <BarChartGroupData>[
+                    for (final _ChartPoint point in points)
+                      BarChartGroupData(
+                        x: point.index,
+                        barRods: <BarChartRodData>[
+                          BarChartRodData(
+                            toY: point.entry.uvi,
+                            color: point.whoColor,
+                            width: _barWidth,
+                            borderRadius: const BorderRadius.vertical(
+                              top: Radius.circular(_barTopRadius),
+                            ),
+                            label: BarChartRodLabel(
+                              offset: const Offset(0, _valueLabelOffsetY),
+                              text: truncateToTenth(
+                                point.entry.uvi,
+                              ).toStringAsFixed(1),
+                              style: labelStyle,
+                            ),
+                          ),
+                        ],
+                      ),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              left: 0,
+              right: 0,
+              top: 0,
+              bottom: _bottomTitleReservedSize,
+              child: _DailyChartSemantics(
+                points: points,
+                plotWidth: constraints.maxWidth,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Formats [localTime] as its abbreviated day-of-week name, e.g. "Mon".
+String _weekdayAbbreviation(DateTime localTime) =>
+    _weekdayAbbreviations[localTime.weekday - 1];
+
+/// An invisible, TalkBack-navigable overlay exposing one semantics node per
+/// daily bar, so screen reader users can swipe through readings without
+/// needing a tap/scrub interaction (out of scope for this widget;
+/// sighted/touch users get only the visual chart).
+///
+/// Each node is positioned at its bar's exact horizontal center rather than
+/// splitting [plotWidth] into equal-width cells, because fl_chart's
+/// [BarChartAlignment.spaceEvenly] lays out fixed-width bars with computed
+/// gaps around them, not as equal-width slices -- an equal split would
+/// misalign the outermost nodes with their bars by a growing margin as the
+/// bar count shrinks.
+///
+/// This exactness depends on invariants enforced elsewhere in this file,
+/// not by the compiler -- changing any of them without updating
+/// [_barCenterX] to match will silently desync this overlay from the
+/// visible bars:
+///  * [UvDailyChart] pins `alignment: BarChartAlignment.spaceEvenly`
+///    explicitly on its `BarChartData` (not left at fl_chart's default).
+///  * Each `BarChartGroupData` has exactly one `BarChartRodData` of width
+///    [_barWidth], so `BarChartGroupData.width == _barWidth`.
+///  * `topTitles`/`leftTitles`/`rightTitles` and `FlBorderData` all stay
+///    hidden, so fl_chart reserves zero horizontal space beyond [plotWidth].
+///  * `BarChart` is never given a `transformationConfig` (pan/zoom), which
+///    would otherwise shrink fl_chart's internal plot width below
+///    [plotWidth].
+class _DailyChartSemantics extends StatelessWidget {
+  const _DailyChartSemantics({required this.points, required this.plotWidth});
+
+  final List<_ChartPoint> points;
+
+  /// The width available to the bar chart's plot area, matching what
+  /// fl_chart's `calculateGroupsX` receives as `viewWidth`.
+  final double plotWidth;
+
+  /// Replicates fl_chart's `BarChartAlignment.spaceEvenly` bar-center
+  /// formula (`calculateGroupsX` in `bar_chart_data_extension.dart`) so
+  /// each semantics node lines up with its bar exactly, not approximately.
+  /// See the invariants this depends on in the class doc above.
+  double _barCenterX(int index) {
+    assert(plotWidth.isFinite && plotWidth >= 0, 'plotWidth must be finite');
+    final double spaceAvailable = plotWidth - (_barWidth * points.length);
+    final double eachSpace = spaceAvailable / (points.length + 1);
+    return eachSpace * (index + 1) + _barWidth * (index + 0.5);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      container: true,
+      explicitChildNodes: true,
+      child: Stack(
+        children: <Widget>[
+          for (final _ChartPoint point in points)
+            Positioned(
+              left: _barCenterX(point.index) - _barWidth / 2,
+              width: _barWidth,
+              top: 0,
+              bottom: 0,
+              child: Semantics(
+                label: _pointLabel(point),
+                child: const SizedBox.expand(),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+
+  String _pointLabel(_ChartPoint point) {
+    final String day = _weekdayAbbreviation(point.localTime);
+    final String value = truncateToTenth(point.entry.uvi).toStringAsFixed(1);
+    final String risk = whoRiskLabel(point.entry.uvi);
+    return '$day, UV max $value, $risk risk';
+  }
+}

--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -94,21 +94,30 @@ class UvDailyChart extends StatelessWidget {
 
     // UvData.daily has no documented ordering guarantee, so sort explicitly
     // -- an out-of-order list would otherwise draw days out of sequence and
-    // expose semantics nodes to TalkBack in the wrong swipe order.
-    final List<UvForecastEntry> sorted = <UvForecastEntry>[
-      for (final UvForecastEntry entry in uvData.daily)
-        if (!_toLocationLocal(entry.time).isBefore(todayDate)) entry,
+    // expose semantics nodes to TalkBack in the wrong swipe order. Sorting
+    // first (on raw entries) lets the filter below compute each entry's
+    // location-local time exactly once, instead of once to filter and again
+    // to build its _ChartPoint.
+    final List<UvForecastEntry> sortedEntries = <UvForecastEntry>[
+      ...uvData.daily,
     ]..sort((UvForecastEntry a, UvForecastEntry b) => a.time.compareTo(b.time));
 
-    final List<_ChartPoint> points = <_ChartPoint>[
-      for (int i = 0; i < sorted.length && i < _daysShown; i++)
-        (
-          index: i,
-          localTime: _toLocationLocal(sorted[i].time),
-          entry: sorted[i],
-          whoColor: whoRiskColor(sorted[i].uvi),
-        ),
-    ];
+    final List<_ChartPoint> points = <_ChartPoint>[];
+    for (final UvForecastEntry entry in sortedEntries) {
+      if (points.length >= _daysShown) {
+        break;
+      }
+      final DateTime localTime = _toLocationLocal(entry.time);
+      if (localTime.isBefore(todayDate)) {
+        continue;
+      }
+      points.add((
+        index: points.length,
+        localTime: localTime,
+        entry: entry,
+        whoColor: whoRiskColor(entry.uvi),
+      ));
+    }
 
     final TextStyle? labelStyle = Theme.of(context).textTheme.bodySmall;
 

--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -63,12 +63,14 @@ typedef _ChartPoint = ({
 /// tap/scrub interaction -- see the "Out of scope" note on the originating
 /// issue for that follow-up.
 class UvDailyChart extends StatelessWidget {
-  /// Creates a [UvDailyChart] from up to the first [_daysShown] entries in
-  /// [UvData.daily].
+  /// Creates a [UvDailyChart] from up to [_daysShown] entries in
+  /// [UvData.daily], chronologically sorted with stale (pre-today,
+  /// location-local) entries dropped first.
   const UvDailyChart({required this.uvData, super.key});
 
-  /// The UV data to chart; only the first [_daysShown] entries of
-  /// [UvData.daily], sorted chronologically, are shown.
+  /// The UV data to chart. [UvData.daily] is sorted chronologically and any
+  /// entry whose location-local date is before today is dropped; up to
+  /// [_daysShown] of what remains is shown.
   final UvData uvData;
 
   /// Converts a UTC [time] to the data's location-local time, using

--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -222,12 +222,16 @@ String _weekdayAbbreviation(DateTime localTime) =>
 /// needing a tap/scrub interaction (out of scope for this widget;
 /// sighted/touch users get only the visual chart).
 ///
-/// Each node is positioned at its bar's exact horizontal center rather than
-/// splitting [plotWidth] into equal-width cells, because fl_chart's
+/// Each node is centered on its bar's exact horizontal center, but sized to
+/// span the full constant spacing between adjacent bar centers (not just
+/// the bar's visible [_barWidth]), applied symmetrically on both sides even
+/// at the outermost bars -- an equal split of [plotWidth] into same-width
+/// slices would instead misalign the outermost nodes with their bars by a
+/// growing margin as the bar count shrinks, since fl_chart's
 /// [BarChartAlignment.spaceEvenly] lays out fixed-width bars with computed
-/// gaps around them, not as equal-width slices -- an equal split would
-/// misalign the outermost nodes with their bars by a growing margin as the
-/// bar count shrinks.
+/// gaps around them, not as equal-width slices. Symmetric cell sizing keeps
+/// every node's rect exactly centered on its bar while still giving
+/// TalkBack a much wider touch target than a narrow [_barWidth]-wide one.
 ///
 /// This exactness depends on invariants enforced elsewhere in this file,
 /// not by the compiler -- changing any of them without updating
@@ -262,6 +266,18 @@ class _DailyChartSemantics extends StatelessWidget {
     return eachSpace * (index + 1) + _barWidth * (index + 0.5);
   }
 
+  /// Half the constant spacing between adjacent bar centers under
+  /// [BarChartAlignment.spaceEvenly] -- used as each semantics node's cell
+  /// half-width, applied symmetrically on both sides of [_barCenterX] (even
+  /// at the outermost bars) so every node's rect stays exactly centered on
+  /// its bar while still spanning far more than [_barWidth].
+  double get _cellHalfWidth {
+    if (points.length < 2) {
+      return plotWidth / 2;
+    }
+    return (_barCenterX(1) - _barCenterX(0)) / 2;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Semantics(
@@ -271,8 +287,15 @@ class _DailyChartSemantics extends StatelessWidget {
         children: <Widget>[
           for (final _ChartPoint point in points)
             Positioned(
-              left: _barCenterX(point.index) - _barWidth / 2,
-              width: _barWidth,
+              // Sized to the full inter-bar cell width, centered on the bar,
+              // rather than just _barWidth, so TalkBack explore-by-touch and
+              // focus targeting aren't confined to the narrow visible bar --
+              // matches _HourlyChartSemantics' full-width Expanded regions.
+              // Applying the same half-width symmetrically at the edges (not
+              // extending to the plot boundary) keeps every node's rect
+              // centered exactly on its bar, matching _barCenterX.
+              left: _barCenterX(point.index) - _cellHalfWidth,
+              width: _cellHalfWidth * 2,
               top: 0,
               bottom: 0,
               child: Semantics(

--- a/lib/widgets/uv_daily_chart.dart
+++ b/lib/widgets/uv_daily_chart.dart
@@ -126,6 +126,20 @@ class UvDailyChart extends StatelessWidget {
 
     return LayoutBuilder(
       builder: (BuildContext context, BoxConstraints constraints) {
+        // asserts are stripped in release builds, so this must also be
+        // checked at runtime: an unbounded-width ancestor (e.g. a
+        // horizontal ListView/SingleChildScrollView this widget is ever
+        // placed in without a bounding constraint) would otherwise make
+        // both fl_chart's own axis-title layout and
+        // _DailyChartSemantics._barCenterX compute non-finite positions,
+        // crashing layout/paint in release mode with no assert to catch it
+        // first. An empty points list has no such risk -- it still renders
+        // a valid, finite-width empty chart -- so it's deliberately not
+        // short-circuited here.
+        if (!constraints.maxWidth.isFinite) {
+          return const SizedBox.shrink();
+        }
+
         return Stack(
           children: <Widget>[
             ExcludeSemantics(
@@ -186,6 +200,12 @@ class UvDailyChart extends StatelessWidget {
                               top: Radius.circular(_barTopRadius),
                             ),
                             label: BarChartRodLabel(
+                              // Pinned explicitly (matching the current
+                              // default), same reasoning as `alignment`
+                              // above: labels can't silently disappear if
+                              // fl_chart's own default ever changes.
+                              // ignore: avoid_redundant_argument_values
+                              show: true,
                               offset: const Offset(0, _valueLabelOffsetY),
                               text: truncateToTenth(
                                 point.entry.uvi,
@@ -249,6 +269,10 @@ String _weekdayAbbreviation(DateTime localTime) =>
 ///  * `BarChart` is never given a `transformationConfig` (pan/zoom), which
 ///    would otherwise shrink fl_chart's internal plot width below
 ///    [plotWidth].
+///  * [UvDailyChart] only constructs this widget once its `LayoutBuilder`
+///    constraints are confirmed finite -- [plotWidth] itself is never
+///    checked here, so a future caller that skips that guard can produce
+///    non-finite [_barCenterX] output.
 class _DailyChartSemantics extends StatelessWidget {
   const _DailyChartSemantics({required this.points, required this.plotWidth});
 

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -14,10 +14,13 @@ import 'fakes/fake_uv_data.dart';
 /// because [UvDailyChart] now drops any daily entry whose location-local
 /// date is in the past -- a hardcoded past date would be silently filtered
 /// out of every fixture below.
-final DateTime _day0 = () {
-  final DateTime now = DateTime.now().toUtc();
-  return DateTime.utc(now.year, now.month, now.day);
-}();
+///
+/// Assigned fresh in [setUp] (not at file-load time) so it can never go
+/// stale relative to [UvDailyChart]'s own `DateTime.now()` call at build
+/// time -- a suite that happens to cross UTC midnight between file load and
+/// a later test's pump would otherwise see that test's fixtures filtered
+/// out as "before today" by the widget's live clock.
+late DateTime _day0;
 
 /// Mirrors the widget's own weekday-abbreviation lookup, so tests can
 /// derive expected labels from [_day0] instead of hardcoding a day-of-week
@@ -37,10 +40,11 @@ String _weekdayAbbreviation(DateTime date) =>
     _weekdayAbbreviations[date.weekday - 1];
 
 /// Abbreviated weekday names for [_day0] and the six days after it.
-final List<String> _weekdaysFromDay0 = <String>[
-  for (int i = 0; i < 7; i++)
-    _weekdayAbbreviation(_day0.add(Duration(days: i))),
-];
+///
+/// Assigned alongside [_day0] in [setUp] for the same midnight-crossing
+/// reason -- it must always be derived from the same `_day0` a test's
+/// fixtures use.
+late List<String> _weekdaysFromDay0;
 
 List<UvForecastEntry> _dailyFrom(
   DateTime start,
@@ -83,6 +87,15 @@ TitleMeta _fakeTitleMeta() => TitleMeta(
 );
 
 void main() {
+  setUp(() {
+    final DateTime now = DateTime.now().toUtc();
+    _day0 = DateTime.utc(now.year, now.month, now.day);
+    _weekdaysFromDay0 = <String>[
+      for (int i = 0; i < 7; i++)
+        _weekdayAbbreviation(_day0.add(Duration(days: i))),
+    ];
+  });
+
   testWidgets('renders one bar group per daily entry, up to 7', (
     WidgetTester tester,
   ) async {

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -156,19 +156,18 @@ void main() {
     expect(_chartData(tester).barGroups, isEmpty);
   });
 
-  testWidgets(
-    'renders without crashing when laid out with unbounded width',
-    (WidgetTester tester) async {
-      final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 7));
+  testWidgets('renders without crashing when laid out with unbounded width', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 7));
 
-      // No exception should escape pumpWidget: _DailyChartSemantics must
-      // bail out via its plotWidth.isFinite guard instead of computing
-      // non-finite Positioned bounds and crashing layout.
-      await tester.pumpWidget(_wrapUnboundedWidth(uvData));
+    // No exception should escape pumpWidget: _DailyChartSemantics must
+    // bail out via its plotWidth.isFinite guard instead of computing
+    // non-finite Positioned bounds and crashing layout.
+    await tester.pumpWidget(_wrapUnboundedWidth(uvData));
 
-      expect(tester.takeException(), isNull);
-    },
-  );
+    expect(tester.takeException(), isNull);
+  });
 
   testWidgets(
     'renders one bar and one full-width semantics node when daily has '
@@ -436,8 +435,7 @@ void main() {
             // node whose local origin already matches its parent's, such as
             // the leftmost cell) -- fall back to an identity translation of
             // 0 rather than assuming a transform always exists.
-            final double translationX =
-                node.transform?.getTranslation().x ?? 0;
+            final double translationX = node.transform?.getTranslation().x ?? 0;
             final double actualCenter = node.rect.center.dx + translationX;
             expect(
               actualCenter,

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -1,0 +1,402 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/models/uv_model.dart';
+import 'package:uvalert/utils/who_risk.dart';
+import 'package:uvalert/widgets/uv_daily_chart.dart';
+
+import 'fakes/fake_uv_data.dart';
+
+/// First day used by [makeUvData]'s defaults, so daily fixtures line up.
+///
+/// Anchored to today (UTC midnight) rather than a fixed historical date,
+/// because [UvDailyChart] now drops any daily entry whose location-local
+/// date is in the past -- a hardcoded past date would be silently filtered
+/// out of every fixture below.
+final DateTime _day0 = () {
+  final DateTime now = DateTime.now().toUtc();
+  return DateTime.utc(now.year, now.month, now.day);
+}();
+
+/// Mirrors the widget's own weekday-abbreviation lookup, so tests can
+/// derive expected labels from [_day0] instead of hardcoding a day-of-week
+/// that would silently go stale once the date this file was written on has
+/// passed.
+const List<String> _weekdayAbbreviations = <String>[
+  'Mon',
+  'Tue',
+  'Wed',
+  'Thu',
+  'Fri',
+  'Sat',
+  'Sun',
+];
+
+String _weekdayAbbreviation(DateTime date) =>
+    _weekdayAbbreviations[date.weekday - 1];
+
+/// Abbreviated weekday names for [_day0] and the six days after it.
+final List<String> _weekdaysFromDay0 = <String>[
+  for (int i = 0; i < 7; i++)
+    _weekdayAbbreviation(_day0.add(Duration(days: i))),
+];
+
+List<UvForecastEntry> _dailyFrom(
+  DateTime start,
+  int count, {
+  double Function(int day)? uviAt,
+}) => <UvForecastEntry>[
+  for (int i = 0; i < count; i++)
+    UvForecastEntry(
+      time: start.add(Duration(days: i)),
+      uvi: uviAt != null ? uviAt(i) : 5,
+    ),
+];
+
+Widget _wrap(UvData uvData, {double width = 400}) => MaterialApp(
+  home: Scaffold(
+    body: SizedBox(
+      width: width,
+      height: 220,
+      child: UvDailyChart(uvData: uvData),
+    ),
+  ),
+);
+
+BarChartData _chartData(WidgetTester tester) =>
+    tester.widget<BarChart>(find.byType(BarChart)).data;
+
+/// A [TitleMeta] fixture for directly invoking a [GetTitleWidgetFunction]
+/// in tests; field values are arbitrary except where the widget under test
+/// reads them.
+TitleMeta _fakeTitleMeta() => TitleMeta(
+  min: 0,
+  max: 6,
+  parentAxisSize: 100,
+  axisPosition: 0,
+  appliedInterval: 1,
+  sideTitles: const SideTitles(),
+  formattedValue: '',
+  axisSide: AxisSide.bottom,
+  rotationQuarterTurns: 0,
+);
+
+void main() {
+  testWidgets('renders one bar group per daily entry, up to 7', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 7));
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    final BarChartData data = _chartData(tester);
+    expect(data.barGroups, hasLength(7));
+    for (final BarChartGroupData group in data.barGroups) {
+      expect(group.barRods, hasLength(1));
+    }
+  });
+
+  testWidgets('trims to 7 bars when daily has more than 7 entries', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 8));
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    expect(_chartData(tester).barGroups, hasLength(7));
+  });
+
+  testWidgets('renders fewer bars when daily has fewer than 7 entries', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 3));
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    expect(_chartData(tester).barGroups, hasLength(3));
+  });
+
+  testWidgets('renders without error when daily is empty', (
+    WidgetTester tester,
+  ) async {
+    // makeUvData()'s daily default is already an empty list; omitted here
+    // to satisfy the analyzer, but that default is exactly what this test
+    // exercises.
+    final UvData uvData = makeUvData();
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    expect(_chartData(tester).barGroups, isEmpty);
+  });
+
+  testWidgets('orders bars chronologically even if daily is not', (
+    WidgetTester tester,
+  ) async {
+    final UvData uvData = makeUvData(
+      daily: <UvForecastEntry>[
+        UvForecastEntry(time: _day0.add(const Duration(days: 2)), uvi: 3),
+        UvForecastEntry(time: _day0, uvi: 1),
+        UvForecastEntry(time: _day0.add(const Duration(days: 1)), uvi: 2),
+      ],
+    );
+
+    await tester.pumpWidget(_wrap(uvData));
+
+    final List<BarChartGroupData> groups = _chartData(tester).barGroups;
+    expect(groups.map((BarChartGroupData g) => g.x), <int>[0, 1, 2]);
+    expect(groups.map((BarChartGroupData g) => g.barRods.single.toY), <double>[
+      1,
+      2,
+      3,
+    ]);
+  });
+
+  group('stale-day filtering', () {
+    testWidgets('drops daily entries dated before today, local time', (
+      WidgetTester tester,
+    ) async {
+      final DateTime yesterday = _day0.subtract(const Duration(days: 1));
+      final UvData uvData = makeUvData(
+        daily: <UvForecastEntry>[
+          UvForecastEntry(time: yesterday, uvi: 9),
+          ..._dailyFrom(_day0, 2),
+        ],
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final List<BarChartGroupData> groups = _chartData(tester).barGroups;
+      expect(groups, hasLength(2));
+      expect(groups.first.barRods.single.toY, isNot(9));
+    });
+
+    testWidgets(
+      'keeps an entry timestamped at the current moment, in a timezone '
+      "where it's already tomorrow in UTC terms",
+      (WidgetTester tester) async {
+        // entry.time is "right now" (UTC), and a +23h offset shifts its
+        // location-local reading almost a full day forward -- still not
+        // before location-local "today", so it must not be dropped as
+        // stale purely because of a large positive timezone offset.
+        final DateTime rightNow = DateTime.now().toUtc();
+        final UvData uvData = makeUvData(
+          daily: <UvForecastEntry>[UvForecastEntry(time: rightNow, uvi: 5)],
+          timezoneOffset: 23 * Duration.secondsPerHour,
+        );
+
+        await tester.pumpWidget(_wrap(uvData));
+
+        expect(_chartData(tester).barGroups, hasLength(1));
+      },
+    );
+  });
+
+  group('WHO risk color mapping', () {
+    testWidgets('each bar is colored per whoRiskColor for its UV value', (
+      WidgetTester tester,
+    ) async {
+      final List<double> uvValues = <double>[1, 4, 6.5, 9, 12];
+      final UvData uvData = makeUvData(
+        daily: _dailyFrom(
+          _day0,
+          uvValues.length,
+          uviAt: (int day) => uvValues[day],
+        ),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final List<Color?> colors = _chartData(
+        tester,
+      ).barGroups.map((BarChartGroupData g) => g.barRods.single.color).toList();
+
+      expect(colors, <Color>[
+        whoColorLow,
+        whoColorModerate,
+        whoColorHigh,
+        whoColorVeryHigh,
+        whoColorExtreme,
+      ]);
+    });
+
+    testWidgets('bar UV value label shows the truncated-to-tenth value', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(
+        daily: _dailyFrom(_day0, 1, uviAt: (int day) => 5.04),
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final BarChartRodLabel label = _chartData(
+        tester,
+      ).barGroups.single.barRods.single.label;
+      expect(label.show, isTrue);
+      expect(label.text, '5.0');
+    });
+  });
+
+  group('day-of-week axis labels', () {
+    testWidgets('labels bars with abbreviated day names in location-local '
+        'time', (WidgetTester tester) async {
+      // Base the fixture one day ahead of _day0, so a -1h offset (which
+      // shifts each entry's location-local date a day earlier) still lands
+      // on/after today -- otherwise the stale-day filter would drop the
+      // shifted-to-yesterday entries this test relies on.
+      final DateTime base = _day0.add(const Duration(days: 1));
+      final UvData uvData = makeUvData(
+        daily: _dailyFrom(base, 3),
+        // -1 hour: a UTC timestamp of midnight becomes 11 PM the previous
+        // local day, proving the axis uses location-local time, not
+        // UTC/device time.
+        timezoneOffset: -Duration.secondsPerHour,
+      );
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final GetTitleWidgetFunction getTitlesWidget = _chartData(
+        tester,
+      ).titlesData.bottomTitles.sideTitles.getTitlesWidget;
+      final TitleMeta meta = _fakeTitleMeta();
+
+      Future<String?> labelAt(double value) async {
+        await tester.pumpWidget(
+          Directionality(
+            textDirection: TextDirection.ltr,
+            child: getTitlesWidget(value, meta),
+          ),
+        );
+        final Finder textFinder = find.byType(Text);
+        if (textFinder.evaluate().isEmpty) return null;
+        return tester.widget<Text>(textFinder).data;
+      }
+
+      // -1h local shifts each bar's local date to the day before its UTC
+      // date, so bar 0 reads as the weekday before `base` -- i.e. _day0.
+      expect(await labelAt(0), _weekdaysFromDay0[0]);
+      expect(await labelAt(1), _weekdaysFromDay0[1]);
+      expect(await labelAt(2), _weekdaysFromDay0[2]);
+    });
+
+    testWidgets('renders nothing for an axis value outside the bar range', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 2));
+
+      await tester.pumpWidget(_wrap(uvData));
+
+      final GetTitleWidgetFunction getTitlesWidget = _chartData(
+        tester,
+      ).titlesData.bottomTitles.sideTitles.getTitlesWidget;
+
+      await tester.pumpWidget(
+        Directionality(
+          textDirection: TextDirection.ltr,
+          child: getTitlesWidget(5, _fakeTitleMeta()),
+        ),
+      );
+
+      expect(find.byType(Text), findsNothing);
+    });
+  });
+
+  group('accessibility semantics', () {
+    testWidgets(
+      'exposes one semantics node per daily bar with day, UV max, and risk',
+      (WidgetTester tester) async {
+        final UvData uvData = makeUvData(
+          daily: _dailyFrom(
+            _day0,
+            3,
+            uviAt: (int day) => <double>[1, 4, 9][day],
+          ),
+        );
+
+        final String label0 = '${_weekdaysFromDay0[0]}, UV max 1.0, Low risk';
+        final String label1 =
+            '${_weekdaysFromDay0[1]}, UV max 4.0, Moderate risk';
+        final String label2 =
+            '${_weekdaysFromDay0[2]}, UV max 9.0, Very High risk';
+
+        final SemanticsHandle handle = tester.ensureSemantics();
+        try {
+          await tester.pumpWidget(_wrap(uvData));
+
+          expect(
+            tester.getSemantics(find.bySemanticsLabel(RegExp(label0))),
+            matchesSemantics(label: label0),
+          );
+          expect(
+            tester.getSemantics(find.bySemanticsLabel(RegExp(label1))),
+            matchesSemantics(label: label1),
+          );
+          expect(
+            tester.getSemantics(find.bySemanticsLabel(RegExp(label2))),
+            matchesSemantics(label: label2),
+          );
+        } finally {
+          handle.dispose();
+        }
+      },
+    );
+
+    testWidgets(
+      "positions each semantics node at its bar's actual horizontal center",
+      (WidgetTester tester) async {
+        const double chartWidth = 400;
+        const double barWidth = 20; // must match _barWidth in the widget.
+        const int count = 7;
+        final UvData uvData = makeUvData(daily: _dailyFrom(_day0, count));
+
+        final SemanticsHandle handle = tester.ensureSemantics();
+        try {
+          await tester.pumpWidget(_wrap(uvData));
+
+          // Mirrors fl_chart's BarChartAlignment.spaceEvenly formula
+          // (calculateGroupsX in bar_chart_data_extension.dart) so this
+          // test fails if the semantics overlay ever drifts from the
+          // chart's actual bar layout again.
+          const double spaceAvailable = chartWidth - barWidth * count;
+          const double eachSpace = spaceAvailable / (count + 1);
+          double expectedCenter(int index) =>
+              eachSpace * (index + 1) + barWidth * (index + 0.5);
+
+          for (int i = 0; i < count; i++) {
+            final String day = _weekdaysFromDay0[i];
+            final SemanticsNode node = tester.getSemantics(
+              find.bySemanticsLabel(RegExp('^${RegExp.escape(day)}, UV max')),
+            );
+            final double actualCenter =
+                node.rect.center.dx + node.transform!.getTranslation().x;
+            expect(
+              actualCenter,
+              closeTo(expectedCenter(i), 0.5),
+              reason: 'bar $i ($day) semantics node is misaligned',
+            );
+          }
+        } finally {
+          handle.dispose();
+        }
+      },
+    );
+
+    testWidgets('excludes the visual chart canvas from the semantics tree', (
+      WidgetTester tester,
+    ) async {
+      final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 3));
+
+      final SemanticsHandle handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(_wrap(uvData));
+
+        final SemanticsNode chartNode = tester.getSemantics(
+          find.byType(BarChart),
+        );
+        expect(chartNode.label, isEmpty);
+      } finally {
+        handle.dispose();
+      }
+    });
+  });
+}

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -173,20 +173,24 @@ void main() {
     'renders one bar and one full-width semantics node when daily has '
     'exactly one entry',
     (WidgetTester tester) async {
-      const double barWidth = 20; // must match _barWidth in the widget.
       final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 1));
 
       final SemanticsHandle handle = tester.ensureSemantics();
       try {
         await tester.pumpWidget(_wrap(uvData));
 
-        expect(_chartData(tester).barGroups, hasLength(1));
+        final BarChartData data = _chartData(tester);
+        expect(data.barGroups, hasLength(1));
+        // Read the actual rendered bar width instead of hardcoding it, so
+        // this assertion stays correct if the widget's private _barWidth
+        // constant is ever changed.
+        final double barWidth = data.barGroups.single.barRods.single.width;
         final SemanticsNode node = tester.getSemantics(
           find.bySemanticsLabel(RegExp('UV max')),
         );
         // With only one bar there is no neighbor on either side, so the
         // node's cell falls back to half the plot width -- still centered
-        // on the single bar, not clipped to _barWidth.
+        // on the single bar, not clipped to the bar's own width.
         expect(node.rect.width, greaterThan(barWidth));
       } finally {
         handle.dispose();
@@ -409,7 +413,6 @@ void main() {
       "positions each semantics node at its bar's actual horizontal center",
       (WidgetTester tester) async {
         const double chartWidth = 400;
-        const double barWidth = 20; // must match _barWidth in the widget.
         const int count = 7;
         final UvData uvData = makeUvData(daily: _dailyFrom(_day0, count));
 
@@ -417,12 +420,19 @@ void main() {
         try {
           await tester.pumpWidget(_wrap(uvData));
 
+          // Read the actual rendered bar width instead of hardcoding it, so
+          // this assertion stays correct if the widget's private _barWidth
+          // constant is ever changed.
+          final double barWidth = _chartData(
+            tester,
+          ).barGroups.first.barRods.single.width;
+
           // Mirrors fl_chart's BarChartAlignment.spaceEvenly formula
           // (calculateGroupsX in bar_chart_data_extension.dart) so this
           // test fails if the semantics overlay ever drifts from the
           // chart's actual bar layout again.
-          const double spaceAvailable = chartWidth - barWidth * count;
-          const double eachSpace = spaceAvailable / (count + 1);
+          final double spaceAvailable = chartWidth - barWidth * count;
+          final double eachSpace = spaceAvailable / (count + 1);
           double expectedCenter(int index) =>
               eachSpace * (index + 1) + barWidth * (index + 0.5);
 

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -130,6 +130,31 @@ void main() {
     expect(_chartData(tester).barGroups, isEmpty);
   });
 
+  testWidgets(
+    'renders one bar and one full-width semantics node when daily has '
+    'exactly one entry',
+    (WidgetTester tester) async {
+      const double barWidth = 20; // must match _barWidth in the widget.
+      final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 1));
+
+      final SemanticsHandle handle = tester.ensureSemantics();
+      try {
+        await tester.pumpWidget(_wrap(uvData));
+
+        expect(_chartData(tester).barGroups, hasLength(1));
+        final SemanticsNode node = tester.getSemantics(
+          find.bySemanticsLabel(RegExp('UV max')),
+        );
+        // With only one bar there is no neighbor on either side, so the
+        // node's cell falls back to half the plot width -- still centered
+        // on the single bar, not clipped to _barWidth.
+        expect(node.rect.width, greaterThan(barWidth));
+      } finally {
+        handle.dispose();
+      }
+    },
+  );
+
   testWidgets('orders bars chronologically even if daily is not', (
     WidgetTester tester,
   ) async {
@@ -367,8 +392,13 @@ void main() {
             final SemanticsNode node = tester.getSemantics(
               find.bySemanticsLabel(RegExp('^${RegExp.escape(day)}, UV max')),
             );
-            final double actualCenter =
-                node.rect.center.dx + node.transform!.getTranslation().x;
+            // node.transform is null when no translation is needed (e.g. a
+            // node whose local origin already matches its parent's, such as
+            // the leftmost cell) -- fall back to an identity translation of
+            // 0 rather than assuming a transform always exists.
+            final double translationX =
+                node.transform?.getTranslation().x ?? 0;
+            final double actualCenter = node.rect.center.dx + translationX;
             expect(
               actualCenter,
               closeTo(expectedCenter(i), 0.5),

--- a/test/uv_daily_chart_test.dart
+++ b/test/uv_daily_chart_test.dart
@@ -68,6 +68,19 @@ Widget _wrap(UvData uvData, {double width = 400}) => MaterialApp(
   ),
 );
 
+/// Wraps [UvDailyChart] in a horizontally-scrolling ancestor with no width
+/// bound, so its `LayoutBuilder` sees `constraints.maxWidth ==
+/// double.infinity` -- reproduces the unbounded-width scenario the
+/// non-finite-plotWidth guard exists for.
+Widget _wrapUnboundedWidth(UvData uvData) => MaterialApp(
+  home: Scaffold(
+    body: SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: SizedBox(height: 220, child: UvDailyChart(uvData: uvData)),
+    ),
+  ),
+);
+
 BarChartData _chartData(WidgetTester tester) =>
     tester.widget<BarChart>(find.byType(BarChart)).data;
 
@@ -142,6 +155,20 @@ void main() {
 
     expect(_chartData(tester).barGroups, isEmpty);
   });
+
+  testWidgets(
+    'renders without crashing when laid out with unbounded width',
+    (WidgetTester tester) async {
+      final UvData uvData = makeUvData(daily: _dailyFrom(_day0, 7));
+
+      // No exception should escape pumpWidget: _DailyChartSemantics must
+      // bail out via its plotWidth.isFinite guard instead of computing
+      // non-finite Positioned bounds and crashing layout.
+      await tester.pumpWidget(_wrapUnboundedWidth(uvData));
+
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
     'renders one bar and one full-width semantics node when daily has '


### PR DESCRIPTION
- Introduce a new UvDailyChart widget to visualize the daily UV index over a week.

- Implement corresponding tests to ensure functionality and accuracy of the chart.

- Ensure the chart displays UV index values with appropriate color coding based on WHO risk levels.

Fixes #20