### PR TITLE
feat: implement government weather alert banner

### DIFF
--- a/docs/adr/0002-owm-one-call-api.md
+++ b/docs/adr/0002-owm-one-call-api.md
@@ -18,4 +18,7 @@ Use OpenWeatherMap One Call API 3.0 on the pay-per-call "One Call by Call" subsc
 - First 1,000 calls/day free, $0.0015/call beyond that
 - Single API covers current UV, 48-hour hourly forecast, 8-day daily forecast, sunrise/sunset
 - No fallback API — if OWM is unreachable, app falls back to cached data
-- Fields not used: minutely, alerts, moon data, temperature, wind, pressure, humidity
+- Fields not used: minutely, moon data, temperature, wind, pressure, humidity
+- `alerts` is used (government weather alert banner, issue #21) despite the
+  original decision to skip it; parsing/binding details tracked separately
+  in `.private/adr/OPEN_QUESTIONS.md`

--- a/docs/adr/0002-owm-one-call-api.md
+++ b/docs/adr/0002-owm-one-call-api.md
@@ -16,7 +16,8 @@ Use OpenWeatherMap One Call API 3.0 on the pay-per-call "One Call by Call" subsc
 ## Consequences
 
 - First 1,000 calls/day free, $0.0015/call beyond that
-- Single API covers current UV, 48-hour hourly forecast, 8-day daily forecast, sunrise/sunset
+- Single API covers current UV, 48-hour hourly forecast, 8-day daily
+  forecast, sunrise/sunset, and government weather alerts
 - No fallback API — if OWM is unreachable, app falls back to cached data
 - Fields not used: minutely, moon data, temperature, wind, pressure, humidity
 - `alerts` is used (government weather alert banner, issue #21) despite the

--- a/lib/models/weather_alert.dart
+++ b/lib/models/weather_alert.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/foundation.dart';
+
+/// A government weather alert to surface on the dashboard banner.
+///
+/// Mirrors the subset of OpenWeatherMap's `alerts[]` entry fields
+/// (`event`, `description`) the banner needs to render. Fetching and
+/// parsing the actual OWM `alerts` payload is out of scope for now -- see
+/// `docs/adr/0002-owm-one-call-api.md` and `.private/adr/OPEN_QUESTIONS.md`.
+@immutable
+class WeatherAlert {
+  /// Creates a [WeatherAlert].
+  const WeatherAlert({required this.event, required this.description});
+
+  /// Deserializes a [WeatherAlert] from a JSON map.
+  ///
+  /// Throws [FormatException] if `event` or `description` is absent.
+  factory WeatherAlert.fromJson(Map<String, Object?> json) {
+    return WeatherAlert(
+      event: json['event'] != null
+          ? json['event']! as String
+          : throw const FormatException('missing required field: event'),
+      description: json['description'] != null
+          ? json['description']! as String
+          : throw const FormatException(
+              'missing required field: description',
+            ),
+    );
+  }
+
+  /// Short alert name, e.g. "Heat Advisory".
+  final String event;
+
+  /// Full alert body text.
+  final String description;
+
+  /// Serializes this instance to a JSON map.
+  Map<String, Object?> toJson() => <String, Object?>{
+    'event': event,
+    'description': description,
+  };
+
+  // Override == for value equality: two alerts with identical fields are
+  // equal regardless of whether they are the same object in memory.
+  // `other` is the Dart SDK's parameter name from Object.==; it is the
+  // right-hand operand being compared against `this`.
+  @override
+  bool operator ==(Object other) =>
+      other is WeatherAlert &&
+      other.event == event &&
+      other.description == description;
+
+  // Override hashCode whenever == is overridden. Dart requires that objects
+  // which are == produce the same hashCode, otherwise Sets and Maps break.
+  @override
+  int get hashCode => Object.hash(event, description);
+}

--- a/lib/models/weather_alert.dart
+++ b/lib/models/weather_alert.dart
@@ -1,5 +1,14 @@
 import 'package:flutter/foundation.dart';
 
+/// Returns `json[field]` as a [String], or throws [FormatException] if the
+/// field is absent.
+String _requireString(Map<String, Object?> json, String field) {
+  final Object? value = json[field];
+  return value != null
+      ? value as String
+      : throw FormatException('missing required field: $field');
+}
+
 /// A government weather alert to surface on the dashboard banner.
 ///
 /// Mirrors the subset of OpenWeatherMap's `alerts[]` entry fields
@@ -16,14 +25,8 @@ class WeatherAlert {
   /// Throws [FormatException] if `event` or `description` is absent.
   factory WeatherAlert.fromJson(Map<String, Object?> json) {
     return WeatherAlert(
-      event: json['event'] != null
-          ? json['event']! as String
-          : throw const FormatException('missing required field: event'),
-      description: json['description'] != null
-          ? json['description']! as String
-          : throw const FormatException(
-              'missing required field: description',
-            ),
+      event: _requireString(json, 'event'),
+      description: _requireString(json, 'description'),
     );
   }
 

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,12 +1,22 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:uvalert/models/weather_alert.dart';
 import 'package:uvalert/screens/settings_screen.dart';
+import 'package:uvalert/widgets/weather_alert_banner.dart';
 
 /// The main screen shown after onboarding completes.
 class DashboardScreen extends StatelessWidget {
   /// Creates a [DashboardScreen].
-  const DashboardScreen({super.key});
+  ///
+  /// [activeAlert] is the government weather alert to surface in the
+  /// banner below the app bar, or `null` when there is none. Fetching and
+  /// parsing the real OWM `alerts` payload is out of scope for now -- see
+  /// [WeatherAlert].
+  const DashboardScreen({this.activeAlert, super.key});
+
+  /// The active alert to show in the dashboard's banner, if any.
+  final WeatherAlert? activeAlert;
 
   @override
   Widget build(BuildContext context) {
@@ -35,7 +45,12 @@ class DashboardScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: const Center(child: Text('Dashboard')),
+      body: Column(
+        children: <Widget>[
+          WeatherAlertBanner(alert: activeAlert),
+          const Expanded(child: Center(child: Text('Dashboard'))),
+        ],
+      ),
     );
   }
 }

--- a/lib/widgets/weather_alert_banner.dart
+++ b/lib/widgets/weather_alert_banner.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:uvalert/models/weather_alert.dart';
+
+/// Horizontal padding inside the banner.
+const double _bannerPaddingHorizontal = 16;
+
+/// Vertical padding inside the banner.
+const double _bannerPaddingVertical = 12;
+
+/// Gap between the warning icon and the alert text.
+const double _iconTextGap = 12;
+
+/// Gap between the dismiss button and the banner's trailing edge.
+const double _dismissButtonGap = 4;
+
+/// Maximum lines shown for the alert description before truncating with an
+/// ellipsis, so an unusually long alert body can't grow the banner enough to
+/// crowd out the rest of the dashboard.
+const int _descriptionMaxLines = 3;
+
+/// A dismissible banner shown below the app bar when an active government
+/// weather alert exists.
+///
+/// Renders nothing when [alert] is `null`. Dismissal is local, in-memory
+/// state: once dismissed, the banner stays hidden until a *different*
+/// [WeatherAlert] (by value) is passed in, at which point it reappears.
+class WeatherAlertBanner extends StatefulWidget {
+  /// Creates a [WeatherAlertBanner] for [alert], or a hidden banner when
+  /// [alert] is `null`.
+  const WeatherAlertBanner({required this.alert, super.key});
+
+  /// The active alert to display, or `null` if there is none.
+  final WeatherAlert? alert;
+
+  @override
+  State<WeatherAlertBanner> createState() => _WeatherAlertBannerState();
+}
+
+class _WeatherAlertBannerState extends State<WeatherAlertBanner> {
+  WeatherAlert? _dismissedAlert;
+
+  @override
+  void didUpdateWidget(WeatherAlertBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // A newly arrived alert (different from whatever was last dismissed)
+    // must reappear even if the user dismissed an earlier one.
+    if (widget.alert != oldWidget.alert) {
+      _dismissedAlert = null;
+    }
+  }
+
+  void _onDismiss() {
+    setState(() => _dismissedAlert = widget.alert);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final WeatherAlert? alert = widget.alert;
+    if (alert == null || alert == _dismissedAlert) {
+      return const SizedBox.shrink();
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+
+    return Material(
+      color: colors.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: _bannerPaddingHorizontal,
+          vertical: _bannerPaddingVertical,
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            ExcludeSemantics(
+              child: Icon(Icons.warning_amber, color: colors.onErrorContainer),
+            ),
+            const SizedBox(width: _iconTextGap),
+            Expanded(
+              child: Semantics(
+                liveRegion: true,
+                label: '${alert.event}. ${alert.description}',
+                child: ExcludeSemantics(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: <Widget>[
+                      Text(
+                        alert.event,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall?.copyWith(
+                          color: colors.onErrorContainer,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Text(
+                        alert.description,
+                        maxLines: _descriptionMaxLines,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colors.onErrorContainer,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+            const SizedBox(width: _dismissButtonGap),
+            IconButton(
+              icon: Icon(Icons.close, color: colors.onErrorContainer),
+              tooltip: 'Dismiss alert',
+              onPressed: _onDismiss,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/weather_alert_banner.dart
+++ b/lib/widgets/weather_alert_banner.dart
@@ -1,18 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:uvalert/models/weather_alert.dart';
 
-/// Horizontal padding inside the banner.
-const double _bannerPaddingHorizontal = 16;
-
-/// Vertical padding inside the banner.
-const double _bannerPaddingVertical = 12;
-
-/// Gap between the warning icon and the alert text.
-const double _iconTextGap = 12;
-
-/// Gap between the dismiss button and the banner's trailing edge.
-const double _dismissButtonGap = 4;
-
 /// Maximum lines shown for the alert description before truncating with an
 /// ellipsis, so an unusually long alert body can't grow the banner enough to
 /// crowd out the rest of the dashboard.
@@ -24,6 +12,11 @@ const int _descriptionMaxLines = 3;
 /// Renders nothing when [alert] is `null`. Dismissal is local, in-memory
 /// state: once dismissed, the banner stays hidden until a *different*
 /// [WeatherAlert] (by value) is passed in, at which point it reappears.
+///
+/// Built on [MaterialBanner] embedded directly in the widget tree (not
+/// shown via `ScaffoldMessenger.showMaterialBanner`), so it renders inline
+/// below the app bar and pushes the rest of the dashboard down, rather than
+/// floating on top of it.
 class WeatherAlertBanner extends StatefulWidget {
   /// Creates a [WeatherAlertBanner] for [alert], or a hidden banner when
   /// [alert] is `null`.
@@ -63,59 +56,46 @@ class _WeatherAlertBannerState extends State<WeatherAlertBanner> {
     final ThemeData theme = Theme.of(context);
     final ColorScheme colors = theme.colorScheme;
 
-    return Material(
-      color: colors.errorContainer,
-      child: Padding(
-        padding: const EdgeInsets.symmetric(
-          horizontal: _bannerPaddingHorizontal,
-          vertical: _bannerPaddingVertical,
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            ExcludeSemantics(
-              child: Icon(Icons.warning_amber, color: colors.onErrorContainer),
-            ),
-            const SizedBox(width: _iconTextGap),
-            Expanded(
-              child: Semantics(
-                liveRegion: true,
-                label: '${alert.event}. ${alert.description}',
-                child: ExcludeSemantics(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      Text(
-                        alert.event,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleSmall?.copyWith(
-                          color: colors.onErrorContainer,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      Text(
-                        alert.description,
-                        maxLines: _descriptionMaxLines,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: colors.onErrorContainer,
-                        ),
-                      ),
-                    ],
-                  ),
+    return MaterialBanner(
+      backgroundColor: colors.errorContainer,
+      leading: ExcludeSemantics(
+        child: Icon(Icons.warning_amber, color: colors.onErrorContainer),
+      ),
+      content: Semantics(
+        liveRegion: true,
+        label: '${alert.event}. ${alert.description}',
+        child: ExcludeSemantics(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                alert.event,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  color: colors.onErrorContainer,
+                  fontWeight: FontWeight.bold,
                 ),
               ),
-            ),
-            const SizedBox(width: _dismissButtonGap),
-            IconButton(
-              icon: Icon(Icons.close, color: colors.onErrorContainer),
-              tooltip: 'Dismiss alert',
-              onPressed: _onDismiss,
-            ),
-          ],
+              Text(
+                alert.description,
+                maxLines: _descriptionMaxLines,
+                overflow: TextOverflow.ellipsis,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: colors.onErrorContainer,
+                ),
+              ),
+            ],
+          ),
         ),
       ),
+      actions: <Widget>[
+        IconButton(
+          icon: Icon(Icons.close, color: colors.onErrorContainer),
+          tooltip: 'Dismiss alert',
+          onPressed: _onDismiss,
+        ),
+      ],
     );
   }
 }

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -70,9 +70,7 @@ void main() {
   testWidgets('renders the alert banner below the app bar when an active '
       'alert is passed in', (WidgetTester tester) async {
     await tester.pumpWidget(
-      const MaterialApp(
-        home: DashboardScreen(activeAlert: _heatAdvisory),
-      ),
+      const MaterialApp(home: DashboardScreen(activeAlert: _heatAdvisory)),
     );
 
     expect(find.text(_heatAdvisory.event), findsOneWidget);

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/models/weather_alert.dart';
 import 'package:uvalert/screens/dashboard_screen.dart';
 import 'package:uvalert/screens/settings_screen.dart';
+
+const WeatherAlert _heatAdvisory = WeatherAlert(
+  event: 'Heat Advisory',
+  description: 'Dangerously high UV and heat index expected today.',
+);
 
 void main() {
   testWidgets('DashboardScreen renders Dashboard text', (
@@ -52,5 +58,24 @@ void main() {
 
     expect(find.text('Dashboard'), findsOneWidget);
     expect(find.byType(SettingsScreen), findsNothing);
+  });
+
+  testWidgets('does not render the alert banner when there is no active '
+      'alert', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: DashboardScreen()));
+
+    expect(find.text(_heatAdvisory.event), findsNothing);
+  });
+
+  testWidgets('renders the alert banner below the app bar when an active '
+      'alert is passed in', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: DashboardScreen(activeAlert: _heatAdvisory),
+      ),
+    );
+
+    expect(find.text(_heatAdvisory.event), findsOneWidget);
+    expect(find.text(_heatAdvisory.description), findsOneWidget);
   });
 }

--- a/test/dashboard_screen_test.dart
+++ b/test/dashboard_screen_test.dart
@@ -77,5 +77,11 @@ void main() {
 
     expect(find.text(_heatAdvisory.event), findsOneWidget);
     expect(find.text(_heatAdvisory.description), findsOneWidget);
+
+    final double appBarBottom = tester.getBottomLeft(find.byType(AppBar)).dy;
+    final double bannerTop = tester
+        .getTopLeft(find.text(_heatAdvisory.event))
+        .dy;
+    expect(bannerTop, greaterThanOrEqualTo(appBarBottom));
   });
 }

--- a/test/weather_alert_banner_test.dart
+++ b/test/weather_alert_banner_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/models/weather_alert.dart';
+import 'package:uvalert/widgets/weather_alert_banner.dart';
+
+const WeatherAlert _heatAdvisory = WeatherAlert(
+  event: 'Heat Advisory',
+  description: 'Dangerously high UV and heat index expected today.',
+);
+
+const WeatherAlert _floodWarning = WeatherAlert(
+  event: 'Flood Warning',
+  description: 'Heavy rainfall may cause flash flooding.',
+);
+
+Widget _wrap(WeatherAlert? alert) =>
+    MaterialApp(home: Scaffold(body: WeatherAlertBanner(alert: alert)));
+
+void main() {
+  testWidgets('renders nothing when there is no active alert', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap(null));
+
+    expect(find.byType(WeatherAlertBanner), findsOneWidget);
+    expect(find.text(_heatAdvisory.event), findsNothing);
+    expect(find.byIcon(Icons.warning_amber), findsNothing);
+  });
+
+  testWidgets('renders the event and description when an alert is active', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(_wrap(_heatAdvisory));
+
+    expect(find.text(_heatAdvisory.event), findsOneWidget);
+    expect(find.text(_heatAdvisory.description), findsOneWidget);
+    expect(find.byIcon(Icons.warning_amber), findsOneWidget);
+  });
+
+  testWidgets('dismiss button hides the banner', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(_heatAdvisory));
+    expect(find.text(_heatAdvisory.event), findsOneWidget);
+
+    await tester.tap(find.byTooltip('Dismiss alert'));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_heatAdvisory.event), findsNothing);
+  });
+
+  testWidgets('dismissing one alert does not suppress a later different '
+      'alert', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(_heatAdvisory));
+    await tester.tap(find.byTooltip('Dismiss alert'));
+    await tester.pumpAndSettle();
+    expect(find.text(_heatAdvisory.event), findsNothing);
+
+    await tester.pumpWidget(_wrap(_floodWarning));
+    await tester.pumpAndSettle();
+
+    expect(find.text(_floodWarning.event), findsOneWidget);
+  });
+
+  testWidgets('dismissing then refreshing to the same unchanged alert '
+      'stays hidden', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(_heatAdvisory));
+    await tester.tap(find.byTooltip('Dismiss alert'));
+    await tester.pumpAndSettle();
+
+    // Simulates a data refresh that returns the same still-active alert.
+    // Built via fromJson (not a const literal) so it's a genuinely distinct
+    // object at runtime -- a const WeatherAlert with the same field values
+    // would canonicalize to the exact same instance as _heatAdvisory,
+    // masking a regression that swapped value-equality for identical().
+    await tester.pumpWidget(
+      _wrap(
+        // A const map here would let the compiler canonicalize the
+        // resulting WeatherAlert back to the same instance as
+        // _heatAdvisory, defeating the point of this test.
+        // ignore: prefer_const_literals_to_create_immutables
+        WeatherAlert.fromJson(<String, Object?>{
+          'event': 'Heat Advisory',
+          'description': 'Dangerously high UV and heat index expected today.',
+        }),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text(_heatAdvisory.event), findsNothing);
+  });
+
+  testWidgets('clearing the alert hides the banner even without a dismiss '
+      'tap', (WidgetTester tester) async {
+    await tester.pumpWidget(_wrap(_heatAdvisory));
+    expect(find.text(_heatAdvisory.event), findsOneWidget);
+
+    await tester.pumpWidget(_wrap(null));
+
+    expect(find.text(_heatAdvisory.event), findsNothing);
+  });
+}

--- a/test/weather_alert_banner_test.dart
+++ b/test/weather_alert_banner_test.dart
@@ -13,8 +13,9 @@ const WeatherAlert _floodWarning = WeatherAlert(
   description: 'Heavy rainfall may cause flash flooding.',
 );
 
-Widget _wrap(WeatherAlert? alert) =>
-    MaterialApp(home: Scaffold(body: WeatherAlertBanner(alert: alert)));
+Widget _wrap(WeatherAlert? alert) => MaterialApp(
+  home: Scaffold(body: WeatherAlertBanner(alert: alert)),
+);
 
 void main() {
   testWidgets('renders nothing when there is no active alert', (

--- a/test/weather_alert_test.dart
+++ b/test/weather_alert_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:uvalert/models/weather_alert.dart';
+
+void main() {
+  const Map<String, Object?> sampleJson = <String, Object?>{
+    'event': 'Heat Advisory',
+    'description': 'Dangerously high UV and heat index expected today.',
+  };
+
+  test('fromJson parses event and description', () {
+    final WeatherAlert alert = WeatherAlert.fromJson(sampleJson);
+
+    expect(alert.event, 'Heat Advisory');
+    expect(
+      alert.description,
+      'Dangerously high UV and heat index expected today.',
+    );
+  });
+
+  test('toJson round-trips through fromJson', () {
+    final WeatherAlert original = WeatherAlert.fromJson(sampleJson);
+    final WeatherAlert roundTripped = WeatherAlert.fromJson(
+      original.toJson(),
+    );
+
+    expect(roundTripped, equals(original));
+  });
+
+  test('equal when event and description match', () {
+    const WeatherAlert a = WeatherAlert(
+      event: 'Flood Warning',
+      description: 'Heavy rainfall may cause flash flooding.',
+    );
+    const WeatherAlert b = WeatherAlert(
+      event: 'Flood Warning',
+      description: 'Heavy rainfall may cause flash flooding.',
+    );
+
+    expect(a, equals(b));
+    expect(a.hashCode, equals(b.hashCode));
+  });
+
+  test('not equal when event differs', () {
+    const WeatherAlert a = WeatherAlert(
+      event: 'Flood Warning',
+      description: 'Same text.',
+    );
+    const WeatherAlert b = WeatherAlert(
+      event: 'Heat Advisory',
+      description: 'Same text.',
+    );
+
+    expect(a, isNot(equals(b)));
+  });
+}

--- a/test/weather_alert_test.dart
+++ b/test/weather_alert_test.dart
@@ -19,9 +19,7 @@ void main() {
 
   test('toJson round-trips through fromJson', () {
     final WeatherAlert original = WeatherAlert.fromJson(sampleJson);
-    final WeatherAlert roundTripped = WeatherAlert.fromJson(
-      original.toJson(),
-    );
+    final WeatherAlert roundTripped = WeatherAlert.fromJson(original.toJson());
 
     expect(roundTripped, equals(original));
   });

--- a/test/weather_alert_test.dart
+++ b/test/weather_alert_test.dart
@@ -17,6 +17,36 @@ void main() {
     );
   });
 
+  test('fromJson throws FormatException when event is missing', () {
+    expect(
+      () => WeatherAlert.fromJson(const <String, Object?>{
+        'description': 'Missing the event field.',
+      }),
+      throwsA(
+        isA<FormatException>().having(
+          (FormatException e) => e.message,
+          'message',
+          'missing required field: event',
+        ),
+      ),
+    );
+  });
+
+  test('fromJson throws FormatException when description is missing', () {
+    expect(
+      () => WeatherAlert.fromJson(const <String, Object?>{
+        'event': 'Heat Advisory',
+      }),
+      throwsA(
+        isA<FormatException>().having(
+          (FormatException e) => e.message,
+          'message',
+          'missing required field: description',
+        ),
+      ),
+    );
+  });
+
   test('toJson round-trips through fromJson', () {
     final WeatherAlert original = WeatherAlert.fromJson(sampleJson);
     final WeatherAlert roundTripped = WeatherAlert.fromJson(original.toJson());


### PR DESCRIPTION
- Add a banner widget that displays below the app bar when an active weather alert exists.

- Ensure the banner is only visible when there is an active alert in the data payload.

- Implement dismiss functionality for the banner once it has been read.

- Include widget tests to verify the banner's visibility, hidden states, and dismiss behavior.

- Update the `DashboardScreen` to integrate the new `WeatherAlertBanner`.

- Create a `WeatherAlert` model to handle alert data.

- Add tests for the `WeatherAlert` model and the `WeatherAlertBanner` widget.

Fixes #21